### PR TITLE
Feature/glue tables readme

### DIFF
--- a/src/glue-tables/README.md
+++ b/src/glue-tables/README.md
@@ -21,6 +21,15 @@ These constructs are utilized as part of the logging strategy defined by
 **stacks/AwsLoggingStack**, but can be deployed individually. They define Glue
 databases, tables, and named Athena queries for ingesting and analyzing each services
 log data from an S3 Bucket.
+- [Common Settings](#CommonSettings)
+- [GlueTables](#GlueTables)
+  - [AlbLogsTable](#AlbLogsTable)
+  - [CloudFrontLogsTable](#CloudFrontLogsTable)
+  - [CloudTrailLogsTable](#CloudTrailLogsTable)
+  - [FlowLogsTable](#FlowLogsTable)
+  - [S3AccessLogsTable](#S3AccessLogsTable)
+  - [SesLogsTable](#SesLogsTable)
+  - [WafLogsTable](#WafLogsTable)
 
 ## Common Settings
 By default, for each service in the **AwsLoggingStack** a Glue crawler performs
@@ -43,3 +52,43 @@ Set `createQueries` to `false` to skip query creation.
 ```Python
 
 ```
+
+## Glue Tables
+### Common Defaults
+
+### AlbLogsTable
+
+#### Glue
+
+#### Athena Queries
+
+### CloudFrontLogsTable
+
+#### Glue
+
+#### Athena Queries
+
+### FlowLogsTable
+
+#### Glue
+
+#### Athena Queries
+
+
+### S3AccessLogsTable
+
+#### Glue
+
+#### Athena Queries
+
+### SesLogsTable
+
+#### Glue
+
+#### Athena Queries
+
+### WafLogsTable
+
+#### Glue
+
+#### Athena Queries

--- a/src/glue-tables/README.md
+++ b/src/glue-tables/README.md
@@ -53,36 +53,202 @@ of your AWS Account. These default named queries have been defined for each AWS
 service.
 
 ## AlbLogsTable
+### Usage
+#### Required Parameters
+- **bucket**: An [AWS S3 iBucket](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3.IBucket.html)
+representing the s3 bucket logs are stored in
+- **database**: A **cdk-extensions/glue** `Database` to create the table in.
+
+**TypeScript**
+```Typescript
+import { AlbLogsTable } from 'cdk-extensions/glue-tables'
+```
+```Typescript
+new AlbLogsTable(this, 'AlbLogsTable', {
+  'bucket': bucket,
+  'database': database
+})
+```
+**Python**
+```Python
+from cdk_extensions.glue_tables import (
+  AlbLogsTable
+)
+```
+```Python
+alb_logging_stack = AlbLogsTable(self, 'AwsLoggingStack',
+                                 bucket=bucket,
+                                 database=database
+                                 )
+```
 
 ### Glue
 
 ### Athena Queries
 
 ## CloudFrontLogsTable
+### Usage
+#### Required Parameters
+- **bucket**: An [AWS S3 iBucket](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3.IBucket.html)
+representing the s3 bucket logs are stored in
+- **database**: A **cdk-extensions/glue** `Database` to create the table in.
 
+**TypeScript**
+```Typescript
+import { CloudFrontLogsTable } from 'cdk-extensions/glue-tables'
+```
+```Typescript
+new CloudFrontLogsTable(this, 'CloudFrontLogsTable', {
+  'bucket': bucket,
+  'database': database
+})
+```
+**Python**
+```Python
+from cdk_extensions.glue_tables import (
+  CloudFrontLogsTable
+)
+```
+```Python
+cloudfront_logging_stack = CloudFrontLogsTable(self, 'AwsLoggingStack',
+                                 bucket=bucket,
+                                 database=database
+                                 )
+```
 ### Glue
 
 ### Athena Queries
 
 ## FlowLogsTable
+### Usage
+#### Required Parameters
+- **bucket**: An [AWS S3 iBucket](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3.IBucket.html)
+representing the s3 bucket logs are stored in
+- **database**: A **cdk-extensions/glue** `Database` to create the table in.
+
+**TypeScript**
+```Typescript
+import { FlowLogsTable } from 'cdk-extensions/glue-tables'
+```
+```Typescript
+new FlowLogsTable(this, 'FlowLogsTable', {
+  'bucket': bucket,
+  'database': database
+})
+```
+**Python**
+```Python
+from cdk_extensions.glue_tables import (
+  FlowLogsTable
+)
+```
+```Python
+flowlogs_stack = FlowLogsTable(self, 'AwsLoggingStack',
+                                 bucket=bucket,
+                                 database=database
+                                 )
+```
 
 ### Glue
 
 ### Athena Queries
 
 ## S3AccessLogsTable
+### Usage
+#### Required Parameters
+- **bucket**: An [AWS S3 iBucket](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3.IBucket.html)
+representing the s3 bucket logs are stored in
+- **database**: A **cdk-extensions/glue** `Database` to create the table in.
+
+**TypeScript**
+```Typescript
+import { S3AccessLogsTable } from 'cdk-extensions/glue-tables'
+```
+```Typescript
+new S3AccessLogsTable(this, 'S3AccessLogsTable', {
+  'bucket': bucket,
+  'database': database
+})
+```
+**Python**
+```Python
+from cdk_extensions.glue_tables import (
+  S3AccessLogsTable
+)
+```
+```Python
+s3_access_logging_stack = S3AccessLogsTable(self, 'AwsLoggingStack',
+                                 bucket=bucket,
+                                 database=database
+                                 )
+```
 
 ### Glue
 
 ### Athena Queries
 
 ## SesLogsTable
+### Usage
+#### Required Parameters
+- **bucket**: An [AWS S3 iBucket](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3.IBucket.html)
+representing the s3 bucket logs are stored in
+- **database**: A **cdk-extensions/glue** `Database` to create the table in.
+
+**TypeScript**
+```Typescript
+import { SesLogsTable } from 'cdk-extensions/glue-tables'
+```
+```Typescript
+new SesLogsTable(this, 'SesLogsTable', {
+  'bucket': bucket,
+  'database': database
+})
+```
+**Python**
+```Python
+from cdk_extensions.glue_tables import (
+  SesLogsTable
+)
+```
+```Python
+ses_logging_stack = SesLogsTable(self, 'AwsLoggingStack',
+                                 bucket=bucket,
+                                 database=database
+                                 )
+```
 
 ### Glue
 
 ### Athena Queries
 
 ## WafLogsTable
+### Usage
+#### Required Paramaters
+- **bucket**: An [AWS S3 iBucket](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3.IBucket.html)
+representing the s3 bucket logs are stored in
+- **database**: A **cdk-extensions/glue** `Database` to create the table in.
+**TypeScript**
+```Typescript
+import { WafLogsTable } from 'cdk-extensions/glue-tables'
+```
+```Typescript
+new WafLogsTable(this, 'WafLogsTable', {
+  'bucket': bucket,
+  'database': database
+})
+```
+**Python**
+```Python
+from cdk_extensions.glue_tables import (
+  WafLogsTable
+)
+```
+```Python
+waf_logging_stack = WafLogsTable(self, 'AwsLoggingStack',
+                                 bucket=bucket,
+                                 database=database
+                                 )
+```
 
 ### Glue
 

--- a/src/glue-tables/README.md
+++ b/src/glue-tables/README.md
@@ -83,8 +83,19 @@ alb_logging_stack = AlbLogsTable(self, 'AwsLoggingStack',
 ```
 
 ### Glue
+Creates a Glue table using constructs from the **cdk_extensions/glue** module.
+Columns are created for all expected ALB log fields.
+
+The following partition keys are set:
+- `source`
+- `logname`
+- `regionname`
+- `day`
+
+Projection is enabled for the expected `mm/dd/yyyy` log format.
 
 ### Athena Queries
+Creates Athena Queries using the **cdk-extensions/athena** module.
 Two Athena [`CfnNamedQueries`](https://docs.aws.amazon.com/cdk/api/v1/python/aws_cdk.aws_athena/CfnNamedQuery.html) are created by default:
 - **alb-top-ips**: Gets the 100 most active IP addresses by request count.
 - **alb-5xx-errors**: Gets the 100 most recent ELB 5XX responses
@@ -119,8 +130,11 @@ cloudfront_logging_stack = CloudFrontLogsTable(self, 'AwsLoggingStack',
                                  )
 ```
 ### Glue
+Creates a Glue table using constructs from the **cdk_extensions/glue** module.
+Columns are created for all expected CloudFront log fields.
 
 ### Athena Queries
+Creates Athena Queries using the **cdk-extensions/athena** constructs.
 Four Athena [`CfnNamedQueries`](https://docs.aws.amazon.com/cdk/api/v1/python/aws_cdk.aws_athena/CfnNamedQuery.html) are created by default:
 - **cloudfront-distribution-statistics**: Gets statistics for CloudFront distributions
   for the last day.
@@ -160,8 +174,17 @@ flowlogs_stack = FlowLogsTable(self, 'AwsLoggingStack',
 ```
 
 ### Glue
+Creates a Glue table using constructs from the **cdk_extensions/glue** module.
+Tables are structured to match expected CloudTrail event logs.
+
+The following partition keys are set:
+- `source`
+- `logname`
+- `regionname`
+- `day`
 
 ### Athena Queries
+Creates Athena Queries using the **cdk-extensions/athena** constructs.
 Two Athena [`CfnNamedQueries`](https://docs.aws.amazon.com/cdk/api/v1/python/aws_cdk.aws_athena/CfnNamedQuery.html) are created by default:
 - **cloudtrail-unauthorized-errors**: Gets the 100 most recent unauthorized AWS
   API calls.
@@ -200,6 +223,7 @@ s3_access_logging_stack = S3AccessLogsTable(self, 'AwsLoggingStack',
 ### Glue
 
 ### Athena Queries
+Creates an Athena Query using the **cdk-extensions/athena** constructs.
 One AthenaNamedQuery is created by default:
 - **s3-request-errors**: Gets the 100 most recent failed S3 access requests.
 
@@ -236,6 +260,7 @@ ses_logging_stack = SesLogsTable(self, 'AwsLoggingStack',
 ### Glue
 
 ### Athena Queries
+Creates Athena Queries using the **cdk-extensions/athena** constructs.
 Two Athena [`CfnNamedQueries`](https://docs.aws.amazon.com/cdk/api/v1/python/aws_cdk.aws_athena/CfnNamedQuery.html) are created by default:
 - **ses-bounces**: Gets the 100 most recent bounces from the last day.
 - **ses-complaints**: Gets the 100 most recent complaints from the last day.

--- a/src/glue-tables/README.md
+++ b/src/glue-tables/README.md
@@ -74,12 +74,12 @@ export class AlbLogStack extends Stack {
     });
 
     // Create a cdk-extensions/glue Database with secure defaults
-    const secure_database = new Database(this, 'GlueDatabase');
+    const database = new Database(this, 'GlueDatabase');
 
     // Create the AlbLogsTable Glue table with defaults
     const alb_logs_table = new AlbLogsTable(this, 'AlbLogsTable', {
       'bucket': bucket,
-      'database': secure_database
+      'database': database
     })
   }
 }

--- a/src/glue-tables/README.md
+++ b/src/glue-tables/README.md
@@ -143,6 +143,53 @@ Four Athena [`CfnNamedQueries`](https://docs.aws.amazon.com/cdk/api/v1/python/aw
 - **cloudfront-top-ips**: Gets the 100 most active IP addresses by request count.
 - **cloudfront-top-objects**: Gets the 100 most requested CloudFront objects.
 
+## CloudTrailTable
+### Usage
+#### Required Parameters
+- **bucket**: An [AWS S3 iBucket](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3.IBucket.html)
+representing the s3 bucket logs are stored in
+- **database**: A **cdk-extensions/glue** `Database` to create the table in.
+
+**TypeScript**
+```Typescript
+import { CloudTrailTable } from 'cdk-extensions/glue-tables'
+```
+```Typescript
+new CloudTrailTable(this, 'CloudTrailTable', {
+  'bucket': bucket,
+  'database': database
+})
+```
+**Python**
+```Python
+from cdk_extensions.glue_tables import (
+  CloudTrailTable
+)
+```
+```Python
+cloudtrail_table_stack = CloudTrailTable(self, 'AwsLoggingStack',
+                                 bucket=bucket,
+                                 database=database
+                                 )
+```
+
+### Glue
+Creates a Glue table using constructs from the **cdk_extensions/glue** module.
+Tables are structured to match expected CloudTrail event logs.
+
+The following partition keys are set:
+- `source`
+- `logname`
+- `regionname`
+- `day`
+
+### Athena Queries
+Creates Athena Queries using the **cdk-extensions/athena** constructs.
+Two Athena [`CfnNamedQueries`](https://docs.aws.amazon.com/cdk/api/v1/python/aws_cdk.aws_athena/CfnNamedQuery.html) are created by default:
+- **cloudtrail-unauthorized-errors**: Gets the 100 most recent unauthorized AWS
+  API calls.
+- **cloudtrail-user-logins**: Gets the 100 most recent AWS user logins.
+
 ## FlowLogsTable
 ### Usage
 #### Required Parameters
@@ -174,21 +221,11 @@ flowlogs_stack = FlowLogsTable(self, 'AwsLoggingStack',
 ```
 
 ### Glue
-Creates a Glue table using constructs from the **cdk_extensions/glue** module.
-Tables are structured to match expected CloudTrail event logs.
-
-The following partition keys are set:
-- `source`
-- `logname`
-- `regionname`
-- `day`
 
 ### Athena Queries
-Creates Athena Queries using the **cdk-extensions/athena** constructs.
-Two Athena [`CfnNamedQueries`](https://docs.aws.amazon.com/cdk/api/v1/python/aws_cdk.aws_athena/CfnNamedQuery.html) are created by default:
-- **cloudtrail-unauthorized-errors**: Gets the 100 most recent unauthorized AWS
-  API calls.
-- **cloudtrail-user-logins**: Gets the 100 most recent AWS user logins.
+One AthenaNamedQuery is created by default:
+- **flow-logs-internal-rejected**: Gets the 100 most recent rejected packets that
+  stayed within the private network ranges.
 
 ## S3AccessLogsTable
 ### Usage

--- a/src/glue-tables/README.md
+++ b/src/glue-tables/README.md
@@ -51,8 +51,9 @@ Several default named queries are defined that aid in improving the security pos
 of your AWS Account. These default named queries have been defined for each AWS
 service.
 
-*Examples*
+### Examples
 
+Creates an ALB Logging stack, with an S3 logging bucket, cdk_extensions Glue database, cdk_extensions `AlbLogsTable` and some default named Athena queries.
 **TypeScript**
 ```typescript
 import { App, Stack, StackProps, RemovalPolicy, aws_s3 as s3 } from 'aws-cdk-lib';
@@ -86,7 +87,40 @@ export class AlbLogStack extends Stack {
 ```
 **Python**
 ```Python
+from constructs import Construct
+from aws_cdk import (
+    RemovalPolicy,
+    Stack,
+    aws_s3 as s3
+)
+from cdk_extensions.glue import (
+  Database
+)
+from cdk_extensions.glue_tables import (
+  AlbLogsTable
+)
 
+
+class AlbLogStack(Stack):
+
+    def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
+        super().__init__(scope, construct_id, **kwargs)
+        # If we were to use the cdk-extensions AlbLogsBucket pattern,
+        # Glue tables would be created for us. Instead, we use the
+        # standard library, remembering to set some secure best practices
+        # like encryption and removal policy
+        bucket = s3.Bucket(self, 'MyEncryptedBucket',
+                           encryption=s3.BucketEncryption.KMS,
+                           removalPolicy=RemovalPolicy.RETAIN
+                           )
+        # Create a cdk-extensions/glue Database with secure defaults
+        database = Database(self, 'MyGlueDatabase')
+        
+        # Create the AlbLogsTable Glue table with defaults
+        alb_logging_stack = AlbLogsTable(self, 'AwsLoggingStack',
+                                         bucket=bucket,
+                                         database=database
+                                         )
 ```
 
 ## AlbLogsTable

--- a/src/glue-tables/README.md
+++ b/src/glue-tables/README.md
@@ -1,0 +1,45 @@
+# Vibe-io CDK-Extensions Glue Tables Construct Library
+The cdk-extensions/glue-tables package contains advanced constructs and patterns
+for setting up Glue databases, tables, and Athena Named Queries. The constructs
+presented here are intended to be replacements for equivalent AWS constructs in
+the CDK module, but with additional features included.All defaults follow best
+practices, and utilize most secure settings.
+
+To import and use this module within your CDK project:
+
+#### Typescript
+```typescript
+import * as glue_tables from 'cdk-extensions/glue-tables';
+```
+#### Python
+```python
+import cdk_extensions.glue_tables as glue_tables
+```
+
+# AWS Logging Tables
+These constructs are utilized as part of the logging strategy defined by
+**stacks/AwsLoggingStack**, but can be deployed individually. They define Glue
+databases, tables, and named Athena queries for ingesting and analyzing each services
+log data from an S3 Bucket.
+
+## Common Settings
+By default, for each service in the **AwsLoggingStack** a Glue crawler performs
+an ETL process to analyze and categorize the stored data and store the associated
+metadata in the AWS Glue Data Catalog.
+
+Several default named queries are defined that aid in improving the security posture
+of your AWS Account. These default named queries have been defined for each AWS
+service.
+
+Set `createQueries` to `false` to skip query creation.
+
+*Examples*
+
+**TypeScript**
+```typescript
+
+```
+**Python**
+```Python
+
+```

--- a/src/glue-tables/README.md
+++ b/src/glue-tables/README.md
@@ -4,6 +4,8 @@ for setting up commonly needed Glue tables and Athena Named Queries. The constru
 presented here are intended to be replacements for equivalent AWS constructs in
 the CDK module, but with additional features included.
 
+[AWS CDK Glue API Reference](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-glue-alpha-readme.html)
+
 The patterns here extend the Glue constructs in the **cdk-extensions/glue** module to
 ensure all defaults follow best practices, and utilize most secure settings.
 
@@ -83,8 +85,7 @@ alb_logging_stack = AlbLogsTable(self, 'AwsLoggingStack',
 ```
 
 ### Glue
-Creates a Glue table using constructs from the **cdk_extensions/glue** module.
-Columns are created for all expected ALB log fields.
+Creates a Glue table using constructs from the **cdk_extensions/glue** module. Table schema is configured for expected ALB log fields.
 
 The following partition keys are set:
 - `source`
@@ -92,7 +93,7 @@ The following partition keys are set:
 - `regionname`
 - `day`
 
-Projection is enabled for the expected `mm/dd/yyyy` log format.
+Projection is enabled and configured for the expected `yyyy/MM/dd` log format.
 
 ### Athena Queries
 Creates Athena Queries using the **cdk-extensions/athena** module.
@@ -130,8 +131,7 @@ cloudfront_logging_stack = CloudFrontLogsTable(self, 'AwsLoggingStack',
                                  )
 ```
 ### Glue
-Creates a Glue table using constructs from the **cdk_extensions/glue** module.
-Columns are created for all expected CloudFront log fields.
+Creates a Glue table using constructs from the **cdk_extensions/glue** module. Table schema is configured for expected CloudFront log fields.
 
 ### Athena Queries
 Creates Athena Queries using the **cdk-extensions/athena** constructs.
@@ -174,14 +174,15 @@ cloudtrail_table_stack = CloudTrailTable(self, 'AwsLoggingStack',
 ```
 
 ### Glue
-Creates a Glue table using constructs from the **cdk_extensions/glue** module.
-Tables are structured to match expected CloudTrail event logs.
+Creates a Glue table using constructs from the **cdk_extensions/glue** module. Table schema is configured for expected CloudTrail event logs data.
 
 The following partition keys are set:
 - `source`
 - `logname`
 - `regionname`
 - `day`
+
+Projection is enabled and configured for the expected `yyyy/MM/dd` log format.
 
 ### Athena Queries
 Creates Athena Queries using the **cdk-extensions/athena** constructs.
@@ -221,6 +222,15 @@ flowlogs_stack = FlowLogsTable(self, 'AwsLoggingStack',
 ```
 
 ### Glue
+Creates a Glue table using constructs from the **cdk_extensions/glue** module. Table schema is configured for expected VPC FlowLog data.
+
+The following partition keys are set:
+- `source`
+- `logname`
+- `regionname`
+- `day`
+
+Projection is enabled and configured for the expected `yyyy/MM/dd` log format.
 
 ### Athena Queries
 One AthenaNamedQuery is created by default:
@@ -258,6 +268,7 @@ s3_access_logging_stack = S3AccessLogsTable(self, 'AwsLoggingStack',
 ```
 
 ### Glue
+Creates a Glue table using constructs from the **cdk_extensions/glue** module. Table schema is configured for expected S3 Access log data.
 
 ### Athena Queries
 Creates an Athena Query using the **cdk-extensions/athena** constructs.
@@ -295,6 +306,12 @@ ses_logging_stack = SesLogsTable(self, 'AwsLoggingStack',
 ```
 
 ### Glue
+Creates a Glue table using constructs from the **cdk_extensions/glue** module. Table schema is configured for the expected SES event logs.
+
+Projection is enabled and configured for the expected `yyyy/MM/dd` log format.
+
+The following partition keys are set:
+- `day`
 
 ### Athena Queries
 Creates Athena Queries using the **cdk-extensions/athena** constructs.
@@ -332,6 +349,13 @@ waf_logging_stack = WafLogsTable(self, 'AwsLoggingStack',
 ```
 
 ### Glue
+Creates a Glue table using constructs from the **cdk_extensions/glue** module. Table schema is configured for expected WAF log data.
+
+The following partition keys are set:
+- `account`
+- `region`
+
+Projection is enabled.
 
 ### Athena Queries
 No default Athena Queries have been implemented at this time.

--- a/src/glue-tables/README.md
+++ b/src/glue-tables/README.md
@@ -5,7 +5,7 @@ presented here are intended to be replacements for equivalent AWS constructs in
 the CDK module, but with additional features included.
 
 The patterns here extend the Glue constructs in the **cdk-extensions/glue** module to
-ensure all defaults follow best practices, and utilize most secure settings. and
+ensure all defaults follow best practices, and utilize most secure settings.
 
 To import and use this module within your CDK project:
 
@@ -37,15 +37,16 @@ an S3 Bucket.
 ### Required Parameters
 These constructs are intended to be used internally by the **AwsLoggingStack**. If
 using them directly, requires:
-- **bucket**: An [AWS S3 iBucket](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3.IBucket.html) representing the s3 bucket logs are stored in
+- **bucket**: An [AWS S3 iBucket](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3.IBucket.html)
+representing the s3 bucket logs are stored in
 - **database**: A **cdk-extensions/glue** `Database` to create the table in.
 
 These tables all expect input from S3_buckets. By default, for each service in
 the **AwsLoggingStack** a Glue crawler performs an ETL process to analyze and categorize
 the stored data and store the associated metadata in the AWS Glue Data Catalog.
 
-For each service, projections are configured where necessary and tables constructed to patterns
-expected for that service.
+For each service, projections are configured where necessary and tables constructed
+to patterns expected for that service.
 
 Several default named queries are defined that aid in improving the security posture
 of your AWS Account. These default named queries have been defined for each AWS

--- a/src/glue-tables/README.md
+++ b/src/glue-tables/README.md
@@ -53,7 +53,8 @@ service.
 
 ### Examples
 
-Creates an ALB Logging stack, with an S3 logging bucket, cdk_extensions Glue database, cdk_extensions `AlbLogsTable` and some default named Athena queries.
+Creates an ALB Logging stack, with an S3 logging bucket, **cdk_extensions/glue** `Database`, and **cdk_extensions** `AlbLogsTable` with some default named Athena queries.
+
 **TypeScript**
 ```typescript
 import { App, Stack, StackProps, RemovalPolicy, aws_s3 as s3 } from 'aws-cdk-lib';
@@ -115,7 +116,7 @@ class AlbLogStack(Stack):
                            )
         # Create a cdk-extensions/glue Database with secure defaults
         database = Database(self, 'MyGlueDatabase')
-        
+
         # Create the AlbLogsTable Glue table with defaults
         alb_logging_stack = AlbLogsTable(self, 'AwsLoggingStack',
                                          bucket=bucket,

--- a/src/glue-tables/README.md
+++ b/src/glue-tables/README.md
@@ -362,7 +362,7 @@ No default Athena Queries have been implemented at this time.
 
 ### Examples
 
-Creates an ALB Logging stack, with an S3 logging bucket, **cdk_extensions/glue** `Database`, and **cdk_extensions** `AlbLogsTable` with some default named Athena queries.
+Creates an ALB Logging stack, with an S3 logging bucket, **cdk_extensions/glue** `Database`, and `AlbLogsTable` with its default Athena Queries.
 
 **TypeScript**
 ```typescript

--- a/src/glue-tables/README.md
+++ b/src/glue-tables/README.md
@@ -48,7 +48,7 @@ the **AwsLoggingStack** a Glue crawler performs an ETL process to analyze and ca
 the stored data and store the associated metadata in the AWS Glue Data Catalog.
 
 For each service, projections are configured where necessary and tables constructed
-to patterns expected for that service.
+to patterns expected for that service, including any necessary SerDe Info.
 
 Several default named queries are defined that aid in improving the security posture
 of your AWS Account. These default named queries have been defined for each AWS

--- a/src/glue-tables/README.md
+++ b/src/glue-tables/README.md
@@ -85,6 +85,9 @@ alb_logging_stack = AlbLogsTable(self, 'AwsLoggingStack',
 ### Glue
 
 ### Athena Queries
+Two Athena [`CfnNamedQueries`](https://docs.aws.amazon.com/cdk/api/v1/python/aws_cdk.aws_athena/CfnNamedQuery.html) are created by default:
+- **alb-top-ips**: Gets the 100 most active IP addresses by request count.
+- **alb-5xx-errors**: Gets the 100 most recent ELB 5XX responses
 
 ## CloudFrontLogsTable
 ### Usage
@@ -118,6 +121,13 @@ cloudfront_logging_stack = CloudFrontLogsTable(self, 'AwsLoggingStack',
 ### Glue
 
 ### Athena Queries
+Four Athena [`CfnNamedQueries`](https://docs.aws.amazon.com/cdk/api/v1/python/aws_cdk.aws_athena/CfnNamedQuery.html) are created by default:
+- **cloudfront-distribution-statistics**: Gets statistics for CloudFront distributions
+  for the last day.
+- **cloudfront-request-errors**: Gets the 100 most recent requests that resulted
+  in an error from CloudFront.
+- **cloudfront-top-ips**: Gets the 100 most active IP addresses by request count.
+- **cloudfront-top-objects**: Gets the 100 most requested CloudFront objects.
 
 ## FlowLogsTable
 ### Usage
@@ -152,6 +162,10 @@ flowlogs_stack = FlowLogsTable(self, 'AwsLoggingStack',
 ### Glue
 
 ### Athena Queries
+Two Athena [`CfnNamedQueries`](https://docs.aws.amazon.com/cdk/api/v1/python/aws_cdk.aws_athena/CfnNamedQuery.html) are created by default:
+- **cloudtrail-unauthorized-errors**: Gets the 100 most recent unauthorized AWS
+  API calls.
+- **cloudtrail-user-logins**: Gets the 100 most recent AWS user logins.
 
 ## S3AccessLogsTable
 ### Usage
@@ -186,6 +200,8 @@ s3_access_logging_stack = S3AccessLogsTable(self, 'AwsLoggingStack',
 ### Glue
 
 ### Athena Queries
+One AthenaNamedQuery is created by default:
+- **s3-request-errors**: Gets the 100 most recent failed S3 access requests.
 
 ## SesLogsTable
 ### Usage
@@ -220,6 +236,9 @@ ses_logging_stack = SesLogsTable(self, 'AwsLoggingStack',
 ### Glue
 
 ### Athena Queries
+Two Athena [`CfnNamedQueries`](https://docs.aws.amazon.com/cdk/api/v1/python/aws_cdk.aws_athena/CfnNamedQuery.html) are created by default:
+- **ses-bounces**: Gets the 100 most recent bounces from the last day.
+- **ses-complaints**: Gets the 100 most recent complaints from the last day.
 
 ## WafLogsTable
 ### Usage

--- a/src/glue-tables/README.md
+++ b/src/glue-tables/README.md
@@ -29,7 +29,7 @@ an S3 Bucket.
 - [GlueTables](#GlueTables)
   - [AlbLogsTable](#AlbLogsTable)
   - [CloudFrontLogsTable](#CloudFrontLogsTable)
-  - [CloudTrailLogsTable](#CloudTrailLogsTable)
+  - [CloudTrailTable](#CloudTrailTable)
   - [FlowLogsTable](#FlowLogsTable)
   - [S3AccessLogsTable](#S3AccessLogsTable)
   - [SesLogsTable](#SesLogsTable)

--- a/src/glue-tables/README.md
+++ b/src/glue-tables/README.md
@@ -1,9 +1,11 @@
 # Vibe-io CDK-Extensions Glue Tables Construct Library
-The cdk-extensions/glue-tables package contains advanced constructs and patterns
-for setting up Glue databases, tables, and Athena Named Queries. The constructs
+The **cdk-extensions/glue-tables** package contains advanced constructs and patterns
+for setting up commonly needed Glue tables and Athena Named Queries. The constructs
 presented here are intended to be replacements for equivalent AWS constructs in
-the CDK module, but with additional features included.All defaults follow best
-practices, and utilize most secure settings.
+the CDK module, but with additional features included.
+
+The patterns here extend the Glue constructs in the **cdk-extensions/glue** module to
+ensure all defaults follow best practices, and utilize most secure settings. and
 
 To import and use this module within your CDK project:
 
@@ -18,9 +20,9 @@ import cdk_extensions.glue_tables as glue_tables
 
 # AWS Logging Tables
 These constructs are utilized as part of the logging strategy defined by
-**stacks/AwsLoggingStack**, but can be deployed individually. They define Glue
-databases, tables, and named Athena queries for ingesting and analyzing each services
-log data from an S3 Bucket.
+**stacks/AwsLoggingStack**, but can be deployed individually. They define Glue tables
+and named Athena queries for ingesting and analyzing each services log data from
+an S3 Bucket.
 - [Common Settings](#CommonSettings)
 - [GlueTables](#GlueTables)
   - [AlbLogsTable](#AlbLogsTable)
@@ -32,63 +34,94 @@ log data from an S3 Bucket.
   - [WafLogsTable](#WafLogsTable)
 
 ## Common Settings
-By default, for each service in the **AwsLoggingStack** a Glue crawler performs
-an ETL process to analyze and categorize the stored data and store the associated
-metadata in the AWS Glue Data Catalog.
+### Required Parameters
+These constructs are intended to be used internally by the **AwsLoggingStack**. If
+using them directly, requires:
+- **bucket**: An [AWS S3 iBucket](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3.IBucket.html) representing the s3 bucket logs are stored in
+- **database**: A **cdk-extensions/glue** `Database` to create the table in.
+
+These tables all expect input from S3_buckets. By default, for each service in
+the **AwsLoggingStack** a Glue crawler performs an ETL process to analyze and categorize
+the stored data and store the associated metadata in the AWS Glue Data Catalog.
+
+For each service, projections are configured where necessary and tables constructed to patterns
+expected for that service.
 
 Several default named queries are defined that aid in improving the security posture
 of your AWS Account. These default named queries have been defined for each AWS
 service.
 
-Set `createQueries` to `false` to skip query creation.
-
 *Examples*
 
 **TypeScript**
 ```typescript
+import { App, Stack, StackProps, RemovalPolicy, aws_s3 as s3 } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { Database } from 'cdk-extensions/glue/database';
+import { AlbLogsTable } from 'cdk-extensions/glue-tables';
 
+export class AlbLogStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    // If we were to use the cdk-extensions AlbLogsBucket pattern,
+    // Glue tables would be created for us. Instead, we use the
+    // standard library, remembering to set some secure best practices
+    // like encryption and removal policy
+    const bucket = new s3.Bucket(this, 'MyEncryptedBucket', {
+      encryption: s3.BucketEncryption.KMS,
+      removalPolicy: RemovalPolicy.RETAIN
+    });
+
+    // Create a cdk-extensions/glue Database with secure defaults
+    const secure_database = new Database(this, 'GlueDatabase');
+
+    // Create the AlbLogsTable Glue table with defaults
+    const alb_logs_table = new AlbLogsTable(this, 'AlbLogsTable', {
+      'bucket': bucket,
+      'database': secure_database
+    })
+  }
+}
 ```
 **Python**
 ```Python
 
 ```
 
-## Glue Tables
-### Common Defaults
+## AlbLogsTable
 
-### AlbLogsTable
+### Glue
 
-#### Glue
+### Athena Queries
 
-#### Athena Queries
+## CloudFrontLogsTable
 
-### CloudFrontLogsTable
+### Glue
 
-#### Glue
+### Athena Queries
 
-#### Athena Queries
+## FlowLogsTable
 
-### FlowLogsTable
+### Glue
 
-#### Glue
+### Athena Queries
 
-#### Athena Queries
+## S3AccessLogsTable
 
+### Glue
 
-### S3AccessLogsTable
+### Athena Queries
 
-#### Glue
+## SesLogsTable
 
-#### Athena Queries
+### Glue
 
-### SesLogsTable
+### Athena Queries
 
-#### Glue
+## WafLogsTable
 
-#### Athena Queries
+### Glue
 
-### WafLogsTable
-
-#### Glue
-
-#### Athena Queries
+### Athena Queries
+No default Athena Queries have been implemented at this time.

--- a/src/glue-tables/README.md
+++ b/src/glue-tables/README.md
@@ -51,6 +51,43 @@ Several default named queries are defined that aid in improving the security pos
 of your AWS Account. These default named queries have been defined for each AWS
 service.
 
+## AlbLogsTable
+
+### Glue
+
+### Athena Queries
+
+## CloudFrontLogsTable
+
+### Glue
+
+### Athena Queries
+
+## FlowLogsTable
+
+### Glue
+
+### Athena Queries
+
+## S3AccessLogsTable
+
+### Glue
+
+### Athena Queries
+
+## SesLogsTable
+
+### Glue
+
+### Athena Queries
+
+## WafLogsTable
+
+### Glue
+
+### Athena Queries
+No default Athena Queries have been implemented at this time.
+
 ### Examples
 
 Creates an ALB Logging stack, with an S3 logging bucket, **cdk_extensions/glue** `Database`, and **cdk_extensions** `AlbLogsTable` with some default named Athena queries.
@@ -123,40 +160,3 @@ class AlbLogStack(Stack):
                                          database=database
                                          )
 ```
-
-## AlbLogsTable
-
-### Glue
-
-### Athena Queries
-
-## CloudFrontLogsTable
-
-### Glue
-
-### Athena Queries
-
-## FlowLogsTable
-
-### Glue
-
-### Athena Queries
-
-## S3AccessLogsTable
-
-### Glue
-
-### Athena Queries
-
-## SesLogsTable
-
-### Glue
-
-### Athena Queries
-
-## WafLogsTable
-
-### Glue
-
-### Athena Queries
-No default Athena Queries have been implemented at this time.


### PR DESCRIPTION
Mostly follows the same format used for the S3_buckets Readme, as, at least for the existing patterns which are all logging tables, they are closely tied together.

For the Glue portions, I gave it my best, but did do some hand-waving and vague summarization that will likely need to be fleshed out/filled in when someone more savvy has the time. I didn't understand SerDe parameters enough to explain how they're being used, but they seem important so they get a passing mention.

A lot of the Glue info *should* eventually exist in the Glue module, so I saw as most critical getting some working examples and usage for each pattern.