### PR TITLE
chore: Feature/aws logging readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ pip install cdk-extensions
 ### Examples
 
 #### AwsLoggingStack
-Minimal deployable example creates the default logging strategy defined in [AwsLoggingStack](./src/stacks/README.md#awsloggingstack) for Elastic Load Balancer, CloudFront, CloudTrail, VPC Flow Logs, S3 access logs, SES logs, and WAF logs. For each service, an S3 bucket is created and a Glue crawler to analyze and categorize the data and store the associated metadata in the AWS Glue Data Catalog. Default named queries have been defined for each AWS service. For more details on this and the other available stacks and constructs, consult the respective READMEs.
+Minimal deployable example creates the default logging strategy defined in [AwsLoggingStack](./src/stacks/README.md#AwsLoggingStack) for Elastic Load Balancer, CloudFront, CloudTrail, VPC Flow Logs, S3 access logs, SES logs, and WAF logs. For each service, an S3 bucket is created and a Glue crawler to analyze and categorize the data and store the associated metadata in the AWS Glue Data Catalog. Default named queries have been defined for each AWS service. For more details on this and the other available stacks and constructs, consult the respective READMEs.
 
 **TypeScript**
 ```TypeScript

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ pip install cdk-extensions
 ### Examples
 
 #### AwsLoggingStack
-Minimal deployable example creates the default logging strategy defined in [AwsLoggingStack](./src/stacks/README.md#AwsLoggingStack) for Elastic Load Balancer, CloudFront, CloudTrail, VPC Flow Logs, S3 access logs, SES logs, and WAF logs. For each service, an S3 bucket is created and a Glue crawler to analyze and categorize the data and store the associated metadata in the AWS Glue Data Catalog. Default named queries have been defined for each AWS service. For more details on this and the other available stacks and constructs, consult the respective READMEs.
+Minimal deployable example creates the default logging strategy defined in [AwsLoggingStack](src/stacks/README.md#awsloggingstack) for Elastic Load Balancer, CloudFront, CloudTrail, VPC Flow Logs, S3 access logs, SES logs, and WAF logs. For each service, an S3 bucket is created and a Glue crawler to analyze and categorize the data and store the associated metadata in the AWS Glue Data Catalog. Default named queries have been defined for each AWS service. For more details on this and the other available stacks and constructs, consult the respective READMEs.
 
 **TypeScript**
 ```TypeScript

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ pip install cdk-extensions
 ### Examples
 
 #### AwsLoggingStack
-Minimal deployable example creates the default logging strategy defined in [AwsLoggingStack](./src/stacks#awsloggingstack) for Elastic Load Balancer, CloudFront, CloudTrail, VPC Flow Logs, S3 access logs, SES logs, and WAF logs. For each service, an S3 bucket is created and a Glue crawler to analyze and categorize the data and store the associated metadata in the AWS Glue Data Catalog. Default named queries have been defined for each AWS service. For more details on this and the other available stacks and constructs, consult the respective READMEs.
+Minimal deployable example creates the default logging strategy defined in [AwsLoggingStack](./src/stacks/README.md#awsloggingstack) for Elastic Load Balancer, CloudFront, CloudTrail, VPC Flow Logs, S3 access logs, SES logs, and WAF logs. For each service, an S3 bucket is created and a Glue crawler to analyze and categorize the data and store the associated metadata in the AWS Glue Data Catalog. Default named queries have been defined for each AWS service. For more details on this and the other available stacks and constructs, consult the respective READMEs.
 
 **TypeScript**
 ```TypeScript

--- a/README.md
+++ b/README.md
@@ -57,3 +57,18 @@ aws_logging_stack = AwsLoggingStack(self, 'AwsLoggingStack')
 ```shell
 $ cdk deploy
 ```
+## CDK-Extensions Design Principles
+### All **cdk-extensions** constructs should
+- Expose their configurations so other resources can make informed
+  decisions about the resource it’s working on.
+- Be fully compatible with **aws-cdk-lib** constructs
+- Expose every single field in the resources, so they can be configured
+  - In some cases, this may rely on custom features built into the **cdk-extensions**
+    constructs, to allow configuration of Cfn fields not normally exposed by CDK
+  - Anything that can be configured on a resource should be something that can
+    be customized using CDK
+- However, all fields have sane defaults, following best practices(i.e most secure way)
+  - Using the most secure settings should be a feature one opts out of, not the
+    other way around
+  - We should be able to launch constructs that adhere to best practices without
+    a lot of customization

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ pip install cdk-extensions
 ### Examples
 
 #### AwsLoggingStack
-Minimal deployable example creates the default logging strategy defined in AwsLoggingStack for Elastic Load Balancer, CloudFront, CloudTrail, VPC Flow Logs, S3 access logs, SES logs, and WAF logs. For each service, an S3 bucket is created and a Glue crawler to analyze and categorize the data and store the associated metadata in the AWS Glue Data Catalog. Default named queries have been defined for each AWS service. For more details on this and the other available stacks and constructs, consult the respective READMEs.
+Minimal deployable example creates the default logging strategy defined in [AwsLoggingStack](./src/stacks#awsloggingstack) for Elastic Load Balancer, CloudFront, CloudTrail, VPC Flow Logs, S3 access logs, SES logs, and WAF logs. For each service, an S3 bucket is created and a Glue crawler to analyze and categorize the data and store the associated metadata in the AWS Glue Data Catalog. Default named queries have been defined for each AWS service. For more details on this and the other available stacks and constructs, consult the respective READMEs.
 
 **TypeScript**
 ```TypeScript

--- a/src/glue-tables/README.md
+++ b/src/glue-tables/README.md
@@ -6,7 +6,7 @@ the CDK module, but with additional features included.
 
 [AWS CDK Glue API Reference](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-glue-alpha-readme.html)
 
-The patterns here extend the Glue constructs in the **cdk-extensions/glue** module to
+The patterns here extend and depend on the Glue constructs in the **cdk-extensions/glue** module(`crawler`, `table`, et al) to
 ensure all defaults follow best practices, and utilize most secure settings.
 
 To import and use this module within your CDK project:
@@ -25,7 +25,8 @@ These constructs are utilized as part of the logging strategy defined by
 **stacks/AwsLoggingStack**, but can be deployed individually. They define Glue tables
 and named Athena queries for ingesting and analyzing each services log data from
 an S3 Bucket.
-- [Common Settings](#CommonSettings)
+- [Usage](#Usage)
+  - [Required Parameters](#RequiredParameters)
 - [GlueTables](#GlueTables)
   - [AlbLogsTable](#AlbLogsTable)
   - [CloudFrontLogsTable](#CloudFrontLogsTable)
@@ -35,24 +36,30 @@ an S3 Bucket.
   - [SesLogsTable](#SesLogsTable)
   - [WafLogsTable](#WafLogsTable)
 
-## Common Settings
-### Required Parameters
+### Usage
+These tables all expect input from S3_buckets. By default, for each service in
+the **AwsLoggingStack**, a Glue crawler performs an ETL process to analyze and categorize
+the stored data and store the associated metadata in the AWS Glue Data Catalog.
+All fields are represented, with handling for nested data as structs.
+
+For each service, projections are configured where necessary and tables constructed
+to patterns expected for that service, including any necessary SerDe Info.
+
+Several default named **Athena** queries are defined using the **cdk_extensions/athena**
+module that aid in improving the security posture of your AWS Account. These named
+queries have been defined for each AWS service.
+
+#### Required Parameters
 These constructs are intended to be used internally by the **AwsLoggingStack**. If
 using them directly, requires:
 - **bucket**: An [AWS S3 iBucket](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3.IBucket.html)
 representing the s3 bucket logs are stored in
 - **database**: A **cdk-extensions/glue** `Database` to create the table in.
 
-These tables all expect input from S3_buckets. By default, for each service in
-the **AwsLoggingStack** a Glue crawler performs an ETL process to analyze and categorize
-the stored data and store the associated metadata in the AWS Glue Data Catalog.
-
-For each service, projections are configured where necessary and tables constructed
-to patterns expected for that service, including any necessary SerDe Info.
-
-Several default named queries are defined that aid in improving the security posture
-of your AWS Account. These default named queries have been defined for each AWS
-service.
+### About ETL
+ETL stands for **E**xtract, **T**ransform, **L**oad. Data is *extracted* from the
+service logs by the Glue crawler, and *transformed* to a proper schema and format
+for *loading* into a Glue table.
 
 ## AlbLogsTable
 ### Usage
@@ -85,7 +92,8 @@ alb_logging_stack = AlbLogsTable(self, 'AwsLoggingStack',
 ```
 
 ### Glue
-Creates a Glue table using constructs from the **cdk_extensions/glue** module. Table schema is configured for expected ALB log fields.
+Creates a Glue table using constructs from the **cdk_extensions/glue** module.
+Table schema is configured for expected ALB log fields.
 
 The following partition keys are set:
 - `source`
@@ -131,7 +139,8 @@ cloudfront_logging_stack = CloudFrontLogsTable(self, 'AwsLoggingStack',
                                  )
 ```
 ### Glue
-Creates a Glue table using constructs from the **cdk_extensions/glue** module. Table schema is configured for expected CloudFront log fields.
+Creates a Glue table using constructs from the **cdk_extensions/glue** module.
+Table schema is configured for expected CloudFront log fields.
 
 ### Athena Queries
 Creates Athena Queries using the **cdk-extensions/athena** constructs.
@@ -174,7 +183,8 @@ cloudtrail_table_stack = CloudTrailTable(self, 'AwsLoggingStack',
 ```
 
 ### Glue
-Creates a Glue table using constructs from the **cdk_extensions/glue** module. Table schema is configured for expected CloudTrail event logs data.
+Creates a Glue table using constructs from the **cdk_extensions/glue** module.
+Table schema is configured for expected CloudTrail event logs data.
 
 The following partition keys are set:
 - `source`
@@ -222,7 +232,8 @@ flowlogs_stack = FlowLogsTable(self, 'AwsLoggingStack',
 ```
 
 ### Glue
-Creates a Glue table using constructs from the **cdk_extensions/glue** module. Table schema is configured for expected VPC FlowLog data.
+Creates a Glue table using constructs from the **cdk_extensions/glue** module.
+Table schema is configured for expected VPC FlowLog data.
 
 The following partition keys are set:
 - `source`
@@ -268,7 +279,8 @@ s3_access_logging_stack = S3AccessLogsTable(self, 'AwsLoggingStack',
 ```
 
 ### Glue
-Creates a Glue table using constructs from the **cdk_extensions/glue** module. Table schema is configured for expected S3 Access log data.
+Creates a Glue table using constructs from the **cdk_extensions/glue** module.
+Table schema is configured for expected S3 Access log data.
 
 ### Athena Queries
 Creates an Athena Query using the **cdk-extensions/athena** constructs.
@@ -306,7 +318,8 @@ ses_logging_stack = SesLogsTable(self, 'AwsLoggingStack',
 ```
 
 ### Glue
-Creates a Glue table using constructs from the **cdk_extensions/glue** module. Table schema is configured for the expected SES event logs.
+Creates a Glue table using constructs from the **cdk_extensions/glue** module.
+Table schema is configured for the expected SES event logs.
 
 Projection is enabled and configured for the expected `yyyy/MM/dd` log format.
 
@@ -349,7 +362,8 @@ waf_logging_stack = WafLogsTable(self, 'AwsLoggingStack',
 ```
 
 ### Glue
-Creates a Glue table using constructs from the **cdk_extensions/glue** module. Table schema is configured for expected WAF log data.
+Creates a Glue table using constructs from the **cdk_extensions/glue** module.
+Table schema is configured for expected WAF log data.
 
 The following partition keys are set:
 - `account`

--- a/src/s3-buckets/README.md
+++ b/src/s3-buckets/README.md
@@ -36,7 +36,7 @@ Glue and Athena can be utilized for fast and efficient analysis of data stored i
 - [Buckets](#Buckets)
   - [AlbLogsBucket](#AlbLogsBucket)
   - [CloudFrontLogsBucket](#CloudFrontLogsBucket)
-  - [CloudTrailLogsBucket](#CloudTrailLogsBucket)
+  - [CloudTrailBucket](#CloudTrailBucket)
   - [FlowLogsBucket](#FlowLogsBucket)
   - [S3AccessLogsBucket](#S3AccessLogsBucket)
   - [SesLogsBucket](#SesLogsBucket)
@@ -66,7 +66,7 @@ const cloudtrail_bucket_without_queries = new s3_buckets.CloudtrailBucket(this, 
 ```Python
 alb_bucket_with_queries = s3_buckets.AlbLogsBucket(self, 'AlbLogsBucket')
 
-cloudtrail_bucket_without_queries = s3_buckets.CloudTrailLogsBucket(self, 'CloudTrailLogsBucket', create_queries=False)
+cloudtrail_bucket_without_queries = s3_buckets.CloudTrailBucket(self, 'CloudTrailBucket', create_queries=False)
 ```
 ## Buckets
 All log buckets are [`CfnBucket`](https://docs.aws.amazon.com/cdk/api/v1/docs/@aws-cdk_aws-s3.CfnBucket.html) constructs
@@ -148,7 +148,7 @@ Four Athena [`CfnNamedQueries`](https://docs.aws.amazon.com/cdk/api/v1/python/aw
 - **cloudfront-top-ips**: Gets the 100 most active IP addresses by request count.
 - **cloudfront-top-objects**: Gets the 100 most requested CloudFront objects.
 
-### CloudTrailLogsBucket
+### CloudTrailBucket
 Creates an S3 Bucket and Glue jobs for storing and analyzing CloudTrail logs.
 By default generates a Glue Database and Table, and creates named Athena
 Queries useful in querying CloudTrail log data.
@@ -156,19 +156,19 @@ Queries useful in querying CloudTrail log data.
 #### Usage
 **TypeScript**
 ```typescript
-import { CloudTrailLogsBucket } from 'cdk-extensions/s3-buckets';
+import { CloudTrailBucket } from 'cdk-extensions/s3-buckets';
 ```
 ```typescript
-new CloudTrailLogsBucket(this, 'CloudTrailLogsBucket')
+new CloudTrailBucket(this, 'CloudTrailBucket')
 ```
 **Python**
 ```python
 from cdk_extensions.s3_buckets import (
-  CloudTrailLogsBucket
+  CloudTrailBucket
 )
 ```
 ```python
-cloudtrail_logs_bucket = CloudTrailLogsBucket(self, 'CloudTrailLogsBucket')
+cloudtrail_logs_bucket = CloudTrailBucket(self, 'CloudTrailBucket')
 ```
 
 #### Glue

--- a/src/s3-buckets/README.md
+++ b/src/s3-buckets/README.md
@@ -76,6 +76,7 @@ with the additional secure defaults:
   `restrictPublicBuckets`)
 - Versioning is set to `Enabled`
 - Server side bucket encryption using AES256
+  - Managed KMS encryption is *not* supported for Service logs
 
 ### AlbLogsBucket
 Creates an S3 Bucket and Glue jobs for storing and analyzing Elastic Load Balancer

--- a/src/s3-buckets/README.md
+++ b/src/s3-buckets/README.md
@@ -115,11 +115,6 @@ Creates an S3 Bucket and Glue jobs for storing and analyzing CloudFront access l
 By default generates a Glue Database and Table, and creates named Athena
 Queries useful in querying CloudFront log data.
 
-### SES
-Protect your domain, and your enterprise's, sending reputation by tracking **bounces**
-and **complaints**
-- **ses-bounces**: Gets the 100 most recent bounces from the last day.
-- **ses-complaints**: Gets the 100 most recent complaints from the last day.
 #### Usage
 **TypeScript**
 ```typescript

--- a/src/s3-buckets/README.md
+++ b/src/s3-buckets/README.md
@@ -115,6 +115,11 @@ Creates an S3 Bucket and Glue jobs for storing and analyzing CloudFront access l
 By default generates a Glue Database and Table, and creates named Athena
 Queries useful in querying CloudFront log data.
 
+### SES
+Protect your domain, and your enterprise's, sending reputation by tracking **bounces**
+and **complaints**
+- **ses-bounces**: Gets the 100 most recent bounces from the last day.
+- **ses-complaints**: Gets the 100 most recent complaints from the last day.
 #### Usage
 **TypeScript**
 ```typescript

--- a/src/stacks/README.md
+++ b/src/stacks/README.md
@@ -128,10 +128,8 @@ import {
   aws_cloudtrail as cloudtrail
 } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
-import { Database } from 'cdk-extensions/lib/glue/database';
-import { AlbLogsTable } from 'cdk-extensions/lib/glue-tables';
-import { AwsLoggingStack } from 'cdk-extensions/lib/stacks';
-import { DeliveryStream } from 'cdk-extensions/lib/kinesis-firehose/delivery-stream'
+import { AwsLoggingStack } from 'cdk-extensions/stacks';
+import { DeliveryStream } from 'cdk-extensions/kinesis-firehose/delivery-stream'
 
 export class DemoStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {

--- a/src/stacks/README.md
+++ b/src/stacks/README.md
@@ -86,22 +86,21 @@ start delivering the logs.
 
 Follow the docs for each service or resource to enable logging to the respective
 `AwsLoggingStack` S3 buckets:
-- [Enable Logging on an ALB](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html#enable-access-logs)
-- [Enable Logging on a CloudFront Distribution](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValuesLoggingOnOff)
-- [Create A Trail on CloudTrail](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-create-a-trail-using-the-console-first-time.html)
-- [Publish VPC Flow Logs to S3](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-s3.html#flow-logs-s3-create-flow-log)
-- [Enable Server Access logging for S3 Access Logs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-access-logging.html#enable-server-logging)
-- [Stream SES Event logs](https://docs.aws.amazon.com/ses/latest/dg/monitor-sending-using-event-publishing-setup.html)
+- [Enable Logging on an ALB](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_elasticloadbalancingv2.ApplicationLoadBalancer.html#logwbraccesswbrlogsbucket-prefix)
+- [Enable Logging on a CloudFront Distribution](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_cloudfront.Distribution.html#enablelogging)
+- [Create A Trail on CloudTrail](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_cloudtrail.Trail.html)
+- [Publish VPC Flow Logs to S3](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ec2.FlowLog.html)
+- [Enable Server Access logging for S3 Access Logs](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3.CfnBucket.LoggingConfigurationProperty.html)
+- [Stream SES Event logs](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ses.CfnConfigurationSetEventDestination.EventDestinationProperty.html)
   - As described in the documentation linked above, SES event logs first need to
-    publish to an intermediate service, such as Kinesis Firehose, and then be streamed
-    to the S3 bucket
-- [Enable WAF logging to S3](https://docs.aws.amazon.com/waf/latest/developerguide/logging-management.html)
+    publish to an intermediate service, such as [Kinesis Firehose](https://docs.aws.amazon.com/cdk/api/v1/docs/aws-kinesisfirehose-readme.html#s3), and then be streamed to the S3 bucket
+- [Enable WAF logging to S3](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_wafv2.CfnLoggingConfiguration.html)
 
 ### The Athena Queries
 Once beyond the nuts and bolts of setting up logging buckets and glue jobs to get
 important data into a secure format that can be queried, your data provides its best
 value through well written Athena queries that draw out important metrics and actionable
-intelligence. The **AwsLoggingStack** creates a few immediately useful [`CfnNamedQueries`](https://docs.aws.amazon.com/cdk/api/v1/python/aws_cdk.aws_athena/CfnNamedQuery.html) for
+intelligence. The **AwsLoggingStack** creates a few immediately useful [`CfnNamedQueries`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_athena.CfnNamedQuery.html) for
 each service to get you started.
 
 #### Application Load Balancer

--- a/src/stacks/README.md
+++ b/src/stacks/README.md
@@ -60,6 +60,7 @@ modules. As such, this stack can be initialized with no parameters to rapidly
 deploy an industry standard logging strategy into an AWS account, including recommended
 named Athena Queries for each service.
 
+#### Install
 To import and use this module within your CDK project:
 
 **TypeScript**
@@ -78,6 +79,23 @@ from cdk_extensions.stacks import (
 ```Python
 aws_logging_stack = AwsLoggingStack(self, 'AwsLoggingStack')
 ```
+
+#### Enable Logging
+**AwsLoggingStack** manages bucket policy and permissions. All that is left is to
+start delivering the logs.
+
+Follow the docs for each service or resource to enable logging to the respective
+`AwsLoggingStack` S3 buckets:
+- [Enable Logging on an ALB](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html#enable-access-logs)
+- [Enable Logging on a CloudFront Distribution](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValuesLoggingOnOff)
+- [Create A Trail on CloudTrail](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-create-a-trail-using-the-console-first-time.html)
+- [Publish VPC Flow Logs to S3](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-s3.html#flow-logs-s3-create-flow-log)
+- [Enable Server Access logging for S3 Access Logs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-access-logging.html#enable-server-logging)
+- [Stream SES Event logs](https://docs.aws.amazon.com/ses/latest/dg/monitor-sending-using-event-publishing-setup.html)
+  - As described in the documentation linked above, SES event logs first need to
+    publish to an intermediate service, such as Kinesis Firehose, and then be streamed
+    to the S3 bucket
+- [Enable WAF logging to S3](https://docs.aws.amazon.com/waf/latest/developerguide/logging-management.html)
 
 ### The Athena Queries
 Once beyond the nuts and bolts of setting up logging buckets and glue jobs to get

--- a/src/stacks/README.md
+++ b/src/stacks/README.md
@@ -206,7 +206,10 @@ publish to an intermediate service, such as [Kinesis Firehose](https://docs.aws.
     aws_ec2 as ec2,
     aws_cloudfront as cloudfront,
     aws_cloudfront_origins as origins,
-    aws_cloudtrail as cloudtrail
+    aws_cloudtrail as cloudtrail,
+    aws_iam as iam,
+    aws_ses as ses,
+    aws_wafv2 as wafv2
   } from 'aws-cdk-lib';
   import { Construct } from 'constructs';
   import { AwsLoggingStack } from 'cdk-extensions/stacks';

--- a/src/stacks/README.md
+++ b/src/stacks/README.md
@@ -1,0 +1,140 @@
+# Vibe-io CDK-Extensions Stacks Library
+These are full-stack solutions, offering rapid deployment of commonly used enterprise
+scale patterns with little to no configuration needed.
+
+- [About](#AboutTheCDK-ExtensionsLibraries)
+- [Stacks](#Stacks)
+  - [AwsLoggingStack](#AwsLoggingStack)
+
+## About The CDK-Extensions Libraries
+All Stacks utilize patterns and constructs from the **cdk-extensions** library.
+
+All **cdk-extensions** constructs:
+- Expose their configurations so other resources can make informed
+  decisions about the resource it’s working on.
+- Are fully compatible with **aws-cdk-lib** constructs
+- Every single field in the resources are exposed, so they can be configured
+  - In some cases, this relies on custom features built into the **cdk-extensions**
+    constructs, to allow configuration of Cfn fields not normally exposed in cdk
+  - Anything that can be configured on a resource should be something that can
+    be customized using CDK
+- However, all fields have sane defaults, following best practices(i.e most secure way)
+  - Using the most secure settings should be a feature one opts out of, not the
+    other way around
+  - We should be able to launch constructs that adhere to best practices without
+    a lot of customization
+
+# Stacks
+
+## AwsLoggingStack
+- [Summary](#Summary)
+- [Usage](#Usage)
+- [The Athena Queries](#TheAthenaQueries)
+  - [Application Load Balancer](#ApplicationLoadBalancer)
+  - [CloudFront](#CloudFront)
+  - [CloudTrail](#CloudTrail)
+  - [VPC FlowLogs](#VPCFlowlogs)
+  - [S3 Access Logs](#S3AccessLogs)
+  - [SES](#SES)
+  - [WAF](#WAF)
+
+### Summary
+Having a good logging strategy for your AWS Services is a recommended best
+practice in every case. It increases operational visibility and strengthens an
+enterprise's security posture in a measurable manner.
+
+**It is *recommended*, but it is not always easy to set up, and it is rarely done
+for you.**
+
+A good logging strategy for AWS services should utilize the most cost effective,
+secure, and reliable solutions available, and include data analysis that can yield
+actionable intelligence.
+
+- This will mean storing logs in S3, typically with secure encryption and versioning
+  enabled, as well as Cfn Retention set.
+- Creating a secure Glue Database for storage and analysis of log data
+- Writing custom Glue jobs that can extract and transform logs from S3, and store
+  them in the Glue database
+- Writing Athena queries tuned for that particular service's log data, that can
+  produce good information, and saving them as named queries
+
+The **AwsLoggingStack** sets that up for seven of the AWS services where it
+is most frequently needed, handling everything from bucket to query for:
+- Application Load Balancer
+- CloudFront
+- CloudTrail
+- VPC FlowLogs
+- S3(Access Logs)
+- SES
+- WAF
+
+
+### Usage
+All S3 buckets, Glue resources, and Athena queries are created using **cdk_extensions**
+modules. As such, this stack can be initialized with no parameters to rapidly
+deploy an industry standard logging strategy into an AWS account, including recommended
+named Athena Queries for each service.
+
+To import and use this module within your CDK project:
+
+**TypeScript**
+```TypeScript
+import { AwsLoggingStack } from 'cdk-extensions/stacks';
+```
+```TypeScript
+new AwsLoggingStack(this, 'AwsLoggingStack')
+```
+**Python**
+```Python
+from cdk_extensions.stacks import (
+  AwsLoggingStack
+)
+```
+```Python
+aws_logging_stack = AwsLoggingStack(self, 'AwsLoggingStack')
+```
+
+### The Athena Queries
+Once beyond the nuts and bolts of setting up logging buckets and glue jobs to get
+important data into a secure format that can be queried, your data provides its best
+value through well written Athena queries that draw out important metrics and actionable
+intelligence. The **AwsLoggingStack** creates a few immediately useful [`CfnNamedQueries`](https://docs.aws.amazon.com/cdk/api/v1/python/aws_cdk.aws_athena/CfnNamedQuery.html) for
+each service to get you started.
+
+#### Application Load Balancer
+Two Athena queries provide valuable insight into traffic to your ALB:
+- **alb-top-ips**: Gets the 100 most active IP addresses by request count.
+- **alb-5xx-errors**: Gets the 100 most recent ELB 5XX responses
+
+#### CloudFront Distribution
+Four Athena queries provide valuable insight into traffic across your CDNs.
+- **cloudfront-distribution-statistics**: Gets statistics for CloudFront distributions
+  for the last day.
+- **cloudfront-request-errors**: Gets the 100 most recent requests that resulted
+  in an error from CloudFront.
+- **cloudfront-top-ips**: Gets the 100 most active IP addresses by request count.
+- **cloudfront-top-objects**: Gets the 100 most requested CloudFront objects.
+
+#### CloudTrail
+Two Athena queries provide valuable insight into user activity on your AWS account.
+- **cloudtrail-unauthorized-errors**: Gets the 100 most recent unauthorized AWS
+  API calls.
+- **cloudtrail-user-logins**: Gets the 100 most recent AWS user logins.
+
+#### VPC FlowLogs
+An Athena query is created to expose info about rejected internal traffic
+- **flow-logs-internal-rejected**: Gets the 100 most recent rejected packets that
+  stayed within the private network ranges.
+
+#### S3 Access Logs
+An Athena query is created that exposes failed attempts to access your S3 buckets
+- **s3-request-errors**: Gets the 100 most recent failed S3 access requests.
+
+#### WAF
+Strategy is implemented for storage of WAF logs in S3 with ETL jobs loading to the
+Glue table, but no default Athena queries have been added yet.
+
+### More Info About The Resources
+This solution utilizes the **AwsLoggingStack** patterns from the **cdk-extensions/glue-tables** and **cdk-extensions/s3-buckets** libraries, which in turn utilize constructs from
+**cdk-extensions** **Glue** and **Athena** libraries. Detailed info about each is
+covered their respective documentation.

--- a/src/stacks/README.md
+++ b/src/stacks/README.md
@@ -94,7 +94,7 @@ Follow the docs for each service or resource to enable logging to the respective
 - [Stream SES Event logs](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ses.CfnConfigurationSetEventDestination.EventDestinationProperty.html)
   - As described in the documentation linked above, SES event logs first need to
     publish to an intermediate service, such as [Kinesis Firehose](https://docs.aws.amazon.com/cdk/api/v1/docs/aws-kinesisfirehose-readme.html#s3), and then be streamed to the S3 bucket(opinionated Firehose constructs are also
-    available in [cdk-extensions/kinesis-firehose](src/kinesis-firehose))
+    available in [cdk-extensions/kinesis-firehose](../kinesis-firehose))
 - [Enable WAF logging to S3](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_wafv2.CfnLoggingConfiguration.html)
 
 ### The Athena Queries

--- a/src/stacks/README.md
+++ b/src/stacks/README.md
@@ -84,7 +84,7 @@ aws_logging_stack = AwsLoggingStack(self, 'AwsLoggingStack')
 ```
 
 #### Enable Logging
-**AwsLoggingStack** manages bucket policy and permissions. All that is left is to
+**AwsLoggingStack** manages buckets, glue tables, and permissions. All that is left is to
 start delivering the logs.
 
 Remember that logging configuration for most **aws-cdk-lib** constructs will require

--- a/src/stacks/README.md
+++ b/src/stacks/README.md
@@ -87,10 +87,10 @@ start delivering the logs.
 Follow the docs for each service or resource to enable logging to the respective
 `AwsLoggingStack` S3 buckets:
 - [Enable Logging on an ALB](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_elasticloadbalancingv2.ApplicationLoadBalancer.html#logwbraccesswbrlogsbucket-prefix)
-- [Enable Logging on a CloudFront Distribution](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_cloudfront.Distribution.html#enablelogging)
+- [Enable Logging on a CloudFront Distribution](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_cloudfront.Distribution.html#logbucket)
 - [Create A Trail on CloudTrail](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_cloudtrail.Trail.html)
 - [Publish VPC Flow Logs to S3](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ec2.FlowLog.html)
-- [Enable Server Access logging for S3 Access Logs](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_cloudfront.Distribution.html#logbucket)
+- [Enable Server Access logging for S3 Access Logs](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3.CfnBucket.LoggingConfigurationProperty.html)
 - [Stream SES Event logs](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ses.CfnConfigurationSetEventDestination.EventDestinationProperty.html)
   - As described in the documentation linked above, SES event logs first need to
     publish to an intermediate service, such as [Kinesis Firehose](https://docs.aws.amazon.com/cdk/api/v1/docs/aws-kinesisfirehose-readme.html#s3), and then be streamed to the S3 bucket(opinionated Firehose constructs are also

--- a/src/stacks/README.md
+++ b/src/stacks/README.md
@@ -13,15 +13,15 @@ All Stacks utilize patterns and constructs from the **cdk-extensions** library.
 ## AwsLoggingStack
 - [Summary](#Summary)
 - [Usage](#Usage)
-- [The Athena Queries](#TheAthenaQueries)
-  - [Application Load Balancer](#ApplicationLoadBalancer)
-  - [CloudFront](#CloudFront)
+- [The Athena Queries](#The-Athena-Queries)
+  - [Application Load Balancer](#Application-Load-Balancer)
+  - [CloudFront](#CloudFront-Distribution)
   - [CloudTrail](#CloudTrail)
-  - [VPC FlowLogs](#VPCFlowlogs)
-  - [S3 Access Logs](#S3AccessLogs)
+  - [VPC FlowLogs](#VPC-Flowlogs)
+  - [S3 Access Logs](#S3-Access-Logs)
   - [SES](#SES)
   - [WAF](#WAF)
-- [More Info About The Resources](#MoreInfoAboutTheResources)
+- [More Info About The Resources](#More-Info-About-The-Resources)
 
 ### Summary
 Having a good logging strategy for your AWS Services is a recommended best

--- a/src/stacks/README.md
+++ b/src/stacks/README.md
@@ -226,10 +226,6 @@ publish to an intermediate service, such as [Kinesis Firehose](https://docs.aws.
 
     constructor(scope: Construct, id: string, props: DemoProps) {
       super(scope, id, props);
-      // Wrap L1 logging bucket in L2 Construct
-      const waf_logs_bucket = s3.Bucket.fromCfnBucket(
-        props.aws_logging_stack.wafLogsBucket.resource
-      );
 
       /**************
       VPC FLOW LOGS

--- a/src/stacks/README.md
+++ b/src/stacks/README.md
@@ -37,6 +37,7 @@ All **cdk-extensions** constructs:
   - [S3 Access Logs](#S3AccessLogs)
   - [SES](#SES)
   - [WAF](#WAF)
+- [More About The Resources](#MoreInfoAboutTheResources)
 
 ### Summary
 Having a good logging strategy for your AWS Services is a recommended best

--- a/src/stacks/README.md
+++ b/src/stacks/README.md
@@ -90,7 +90,7 @@ Follow the docs for each service or resource to enable logging to the respective
 - [Enable Logging on a CloudFront Distribution](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_cloudfront.Distribution.html#enablelogging)
 - [Create A Trail on CloudTrail](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_cloudtrail.Trail.html)
 - [Publish VPC Flow Logs to S3](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ec2.FlowLog.html)
-- [Enable Server Access logging for S3 Access Logs](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3.CfnBucket.LoggingConfigurationProperty.html)
+- [Enable Server Access logging for S3 Access Logs](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_cloudfront.Distribution.html#logbucket)
 - [Stream SES Event logs](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ses.CfnConfigurationSetEventDestination.EventDestinationProperty.html)
   - As described in the documentation linked above, SES event logs first need to
     publish to an intermediate service, such as [Kinesis Firehose](https://docs.aws.amazon.com/cdk/api/v1/docs/aws-kinesisfirehose-readme.html#s3), and then be streamed to the S3 bucket(opinionated Firehose constructs are also

--- a/src/stacks/README.md
+++ b/src/stacks/README.md
@@ -6,7 +6,7 @@ All Stacks utilize patterns and constructs from the **cdk-extensions** library.
 
 - [About](#AboutTheCDK-ExtensionsLibraries)
 - [Stacks](#Stacks)
-  - [AwsLoggingStack](#AwsLoggingStack)
+- [AwsLoggingStack](#AwsLoggingStack)
 
 # Stacks
 
@@ -14,13 +14,13 @@ All Stacks utilize patterns and constructs from the **cdk-extensions** library.
 - [Summary](#Summary)
 - [Usage](#Usage)
 - [The Athena Queries](#The-Athena-Queries)
-  - [Application Load Balancer](#Application-Load-Balancer)
-  - [CloudFront](#CloudFront-Distribution)
-  - [CloudTrail](#CloudTrail)
-  - [VPC FlowLogs](#VPC-Flowlogs)
-  - [S3 Access Logs](#S3-Access-Logs)
-  - [SES](#SES)
-  - [WAF](#WAF)
+- [Application Load Balancer](#Application-Load-Balancer)
+- [CloudFront](#CloudFront-Distribution)
+- [CloudTrail](#CloudTrail)
+- [VPC FlowLogs](#VPC-Flowlogs)
+- [S3 Access Logs](#S3-Access-Logs)
+- [SES](#SES)
+- [WAF](#WAF)
 - [More Info About The Resources](#More-Info-About-The-Resources)
 - [Examples](#Examples)
 
@@ -37,12 +37,12 @@ secure, and reliable solutions available, and include data analysis that can yie
 actionable intelligence.
 
 - This will mean storing logs in S3, typically with secure encryption and versioning
-  enabled, as well as Cfn Retention set.
+enabled, as well as Cfn Retention set.
 - Creating a secure Glue Database for storage and analysis of log data
 - Writing custom Glue jobs that can extract and transform logs from S3, and store
-  them in the Glue database
+them in the Glue database
 - Writing Athena queries tuned for that particular service's log data, that can
-  produce good information, and saving them as named queries
+produce good information, and saving them as named queries
 
 The **AwsLoggingStack** sets that up for seven of the AWS services where it
 is most frequently needed, handling everything from bucket to query for:
@@ -76,7 +76,7 @@ new AwsLoggingStack(this, 'AwsLoggingStack')
 **Python**
 ```Python
 from cdk_extensions.stacks import (
-  AwsLoggingStack
+AwsLoggingStack
 )
 ```
 ```Python
@@ -100,8 +100,8 @@ const l2_cloudtrail_bucket = s3.Bucket.fromCfnBucket(
 );
 
 const trail = new cloudtrail.Trail(this, 'myCloudTrail', {
-      bucket: l2_cloudtrail_bucket
-    });
+  bucket: l2_cloudtrail_bucket
+});
 ```
 
 Follow the docs for each service or resource to enable logging to the respective
@@ -112,282 +112,306 @@ Follow the docs for each service or resource to enable logging to the respective
 - [Publish VPC Flow Logs to S3](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ec2.FlowLogDestination.html#static-towbrs3bucket-keyprefix-options)
 - [Enable Server Access logging for S3 Access Logs](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3.CfnBucket.LoggingConfigurationProperty.html)
 - [Stream SES Event logs](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ses.CfnConfigurationSetEventDestination.EventDestinationProperty.html)
-  - As described in the documentation linked above, SES event logs first need to
-    publish to an intermediate service, such as [Kinesis Firehose](https://docs.aws.amazon.com/cdk/api/v1/docs/aws-kinesisfirehose-readme.html#s3), and then be streamed to the S3 bucket(opinionated Firehose constructs are also
-    available in [cdk-extensions/kinesis-firehose](../kinesis-firehose))
-- [Enable WAF logging to S3](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_wafv2.CfnLoggingConfiguration.html)
+- As described in the documentation linked above, SES event logs first need to
+publish to an intermediate service, such as [Kinesis Firehose](https://docs.aws.amazon.com/cdk/api/v1/docs/aws-kinesisfirehose-readme.html#s3), and then be streamed to the S3 bucket(opinionated Firehose constructs are also
+  available in [cdk-extensions/kinesis-firehose](../kinesis-firehose))
+  - [Enable WAF logging to S3](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_wafv2.CfnLoggingConfiguration.html)
 
-### The Athena Queries
-Once beyond the nuts and bolts of setting up logging buckets and glue jobs to get
-important data into a secure format that can be queried, your data provides its best
-value through well written Athena queries that draw out important metrics and actionable
-intelligence. The **AwsLoggingStack** creates a few immediately useful [`CfnNamedQueries`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_athena.CfnNamedQuery.html) for
-each service to get you started.
+  ### The Athena Queries
+  Once beyond the nuts and bolts of setting up logging buckets and glue jobs to get
+  important data into a secure format that can be queried, your data provides its best
+  value through well written Athena queries that draw out important metrics and actionable
+  intelligence. The **AwsLoggingStack** creates a few immediately useful [`CfnNamedQueries`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_athena.CfnNamedQuery.html) for
+  each service to get you started.
 
-#### Application Load Balancer
-Two Athena queries provide valuable insight into traffic to your ALB:
-- **alb-top-ips**: Gets the 100 most active IP addresses by request count.
-- **alb-5xx-errors**: Gets the 100 most recent ELB 5XX responses
+  #### Application Load Balancer
+  Two Athena queries provide valuable insight into traffic to your ALB:
+  - **alb-top-ips**: Gets the 100 most active IP addresses by request count.
+  - **alb-5xx-errors**: Gets the 100 most recent ELB 5XX responses
 
-#### CloudFront Distribution
-Four Athena queries provide valuable insight into traffic across your CDNs.
-- **cloudfront-distribution-statistics**: Gets statistics for CloudFront distributions
+  #### CloudFront Distribution
+  Four Athena queries provide valuable insight into traffic across your CDNs.
+  - **cloudfront-distribution-statistics**: Gets statistics for CloudFront distributions
   for the last day.
-- **cloudfront-request-errors**: Gets the 100 most recent requests that resulted
+  - **cloudfront-request-errors**: Gets the 100 most recent requests that resulted
   in an error from CloudFront.
-- **cloudfront-top-ips**: Gets the 100 most active IP addresses by request count.
-- **cloudfront-top-objects**: Gets the 100 most requested CloudFront objects.
+  - **cloudfront-top-ips**: Gets the 100 most active IP addresses by request count.
+  - **cloudfront-top-objects**: Gets the 100 most requested CloudFront objects.
 
-#### CloudTrail
-Two Athena queries provide valuable insight into user activity on your AWS account.
-- **cloudtrail-unauthorized-errors**: Gets the 100 most recent unauthorized AWS
+  #### CloudTrail
+  Two Athena queries provide valuable insight into user activity on your AWS account.
+  - **cloudtrail-unauthorized-errors**: Gets the 100 most recent unauthorized AWS
   API calls.
-- **cloudtrail-user-logins**: Gets the 100 most recent AWS user logins.
+  - **cloudtrail-user-logins**: Gets the 100 most recent AWS user logins.
 
-#### VPC FlowLogs
-An Athena query is created to expose info about rejected internal traffic
-- **flow-logs-internal-rejected**: Gets the 100 most recent rejected packets that
+  #### VPC FlowLogs
+  An Athena query is created to expose info about rejected internal traffic
+  - **flow-logs-internal-rejected**: Gets the 100 most recent rejected packets that
   stayed within the private network ranges.
 
-#### S3 Access Logs
-An Athena query is created that exposes failed attempts to access your S3 buckets
-- **s3-request-errors**: Gets the 100 most recent failed S3 access requests.
+  #### S3 Access Logs
+  An Athena query is created that exposes failed attempts to access your S3 buckets
+  - **s3-request-errors**: Gets the 100 most recent failed S3 access requests.
 
-#### SES
-Protect your domain, and your enterprise's, sending reputation by tracking **bounces**
-and **complaints**
-- **ses-bounces**: Gets the 100 most recent bounces from the last day.
-- **ses-complaints**: Gets the 100 most recent complaints from the last day.
+  #### SES
+  Protect your domain, and your enterprise's, sending reputation by tracking **bounces**
+  and **complaints**
+  - **ses-bounces**: Gets the 100 most recent bounces from the last day.
+  - **ses-complaints**: Gets the 100 most recent complaints from the last day.
 
-#### WAF
-Strategy is implemented for storage of WAF logs in S3 with ETL jobs loading to the
-Glue table, but no default Athena queries have been added yet.
+  #### WAF
+  Strategy is implemented for storage of WAF logs in S3 with ETL jobs loading to the
+  Glue table, but no default Athena queries have been added yet.
 
-### More Info About The Resources
-This solution utilizes the **AwsLoggingStack** patterns from the **cdk-extensions/glue-tables** and **cdk-extensions/s3-buckets** libraries, which in turn utilize constructs from
-**cdk-extensions** **Glue** and **Athena** libraries. Detailed info about each is
-covered their respective documentation.
+  ### More Info About The Resources
+  This solution utilizes the **AwsLoggingStack** patterns from the **cdk-extensions/glue-tables** and **cdk-extensions/s3-buckets** libraries, which in turn utilize constructs from
+  **cdk-extensions** **Glue** and **Athena** libraries. Detailed info about each is
+  covered their respective documentation.
 
-### Examples
-#### TypeScript
-*bin/demo.ts*
-```typescript
-#!/usr/bin/env node
-import * as cdk from 'aws-cdk-lib';
-import { DemoStack } from '../lib/demo-stack';
-import { AwsLoggingStack } from 'cdk-extensions/stacks';
+  ### Examples
+  #### TypeScript
+  *bin/demo.ts*
+  ```typescript
+  #!/usr/bin/env node
+  import * as cdk from 'aws-cdk-lib';
+  import { DemoStack } from '../lib/demo-stack';
+  import { AwsLoggingStack } from 'cdk-extensions/stacks';
 
-const app = new cdk.App();
+  const app = new cdk.App();
 
-// For some cases, like ALB and Flow Logs, we can not have an environment agnostic
-// stack
-const env = {
-  account: process.env.CDK_DEFAULT_ACCOUNT,
-  region: process.env.CDK_DEFAULT_REGION
-}
+  // For some cases, like ALB and Flow Logs, we can not have an environment agnostic
+  // stack
+  const env = {
+    account: process.env.CDK_DEFAULT_ACCOUNT,
+    region: process.env.CDK_DEFAULT_REGION
+  }
 
-const aws_logging_stack = new AwsLoggingStack(app, 'AwsLoggingStack', {
-  env: env
-});
+  const aws_logging_stack = new AwsLoggingStack(app, 'AwsLoggingStack', {
+    env: env
+  });
 
-new DemoStack(app, 'DemoStack', {
-  env: env,
-  aws_logging_stack: aws_logging_stack
-});
-```
-*/lib/demo-stack*
-```TypeScript
-import {
-  App,
-  Stack,
-  StackProps,
-  aws_s3 as s3,
-  aws_elasticloadbalancingv2 as elbv2,
-  aws_ec2 as ec2,
-  aws_cloudfront as cloudfront,
-  aws_cloudfront_origins as origins,
-  aws_cloudtrail as cloudtrail
-} from 'aws-cdk-lib';
-import { Construct } from 'constructs';
-import { AwsLoggingStack } from 'cdk-extensions/stacks';
-import * as firehose from '@aws-cdk/aws-kinesisfirehose-alpha';
-import { S3Bucket } from '@aws-cdk/aws-kinesisfirehose-destinations-alpha';
+  new DemoStack(app, 'DemoStack', {
+    env: env,
+    aws_logging_stack: aws_logging_stack
+  });
+  ```
+  */lib/demo-stack*
+  ```TypeScript
+  import {
+    App,
+    Stack,
+    StackProps,
+    aws_s3 as s3,
+    aws_elasticloadbalancingv2 as elbv2,
+    aws_ec2 as ec2,
+    aws_cloudfront as cloudfront,
+    aws_cloudfront_origins as origins,
+    aws_cloudtrail as cloudtrail
+  } from 'aws-cdk-lib';
+  import { Construct } from 'constructs';
+  import { AwsLoggingStack } from 'cdk-extensions/stacks';
+  import * as firehose from '@aws-cdk/aws-kinesisfirehose-alpha';
+  import { S3Bucket } from '@aws-cdk/aws-kinesisfirehose-destinations-alpha';
 
-export interface DemoProps extends StackProps {
-  readonly aws_logging_stack: AwsLoggingStack;
-}
+  export interface DemoProps extends StackProps {
+    readonly aws_logging_stack: AwsLoggingStack;
+  }
 
-export class DemoStack extends Stack {
-  // input properties
-  public readonly aws_logging_stack: AwsLoggingStack;
+  export class DemoStack extends Stack {
+    // input properties
+    public readonly aws_logging_stack: AwsLoggingStack;
 
-  constructor(scope: Construct, id: string, props: DemoProps) {
-    super(scope, id, props);
-    // Wrap L1 logging bucket in L2 Construct
-    const waf_logs_bucket = s3.Bucket.fromCfnBucket(
-      props.aws_logging_stack.wafLogsBucket.resource
-    );
+    constructor(scope: Construct, id: string, props: DemoProps) {
+      super(scope, id, props);
+      // Wrap L1 logging bucket in L2 Construct
+      const waf_logs_bucket = s3.Bucket.fromCfnBucket(
+        props.aws_logging_stack.wafLogsBucket.resource
+      );
 
-    // Create the demo resources
+      /**************
+      VPC FLOW LOGS
+      ***************/
+      // Wrap L1 logging bucket in L2 Construct
+      const flow_logs_bucket = s3.Bucket.fromCfnBucket(
+        props.aws_logging_stack.flowLogsBucket.resource
+      );
+      // Create a VPC
+      const vpc = new ec2.Vpc(this, 'VPC');
+      // Enable flow log output to the FlowLogs bucket for the new VPC
+      new ec2.FlowLog(this, 'FlowLog', {
+        resourceType: ec2.FlowLogResourceType.fromVpc(vpc),
+        destination: ec2.FlowLogDestination.toS3(
+          flow_logs_bucket
+        )
+      });
 
-    // Create a VPC
-    const vpc = new ec2.Vpc(this, 'VPC');
 
-    /*
-      FLOW LOGS
-    */
-    // Wrap L1 logging bucket in L2 Construct
-    const flow_logs_bucket = s3.Bucket.fromCfnBucket(
-      props.aws_logging_stack.flowLogsBucket.resource
-    );
-    // Enable flow log output to the FlowLogs bucket for the new VPC
-    new ec2.FlowLog(this, 'FlowLog', {
-      resourceType: ec2.FlowLogResourceType.fromVpc(vpc),
-      destination: ec2.FlowLogDestination.toS3(
-        flow_logs_bucket
-      )
-    });
-
-    /*
+      /***************
       S3 ACCESS LOGS
-    */
-    const s3_access_logs_bucket = s3.Bucket.fromCfnBucket(
-      props.aws_logging_stack.s3AccessLogsBucket.resource
-    );
-    // Create a simple S3 bucket, with access logging sent to
-    // the s3AccessLogsBucket
-    const s3Bucket = new s3.Bucket(this, 'WebsiteBucket', {
-      serverAccessLogsBucket: s3_access_logs_bucket
-    });
+      ****************/
+      const s3_access_logs_bucket = s3.Bucket.fromCfnBucket(
+        props.aws_logging_stack.s3AccessLogsBucket.resource
+      );
+      // Create a simple S3 bucket, with access logging sent to
+      // the s3AccessLogsBucket
+      const s3Bucket = new s3.Bucket(this, 'WebsiteBucket', {
+        serverAccessLogsBucket: s3_access_logs_bucket
+      });
 
-    /*
+
+      /****************
       CLOUDFRONT LOGS
-    */
-    // Wrap L1 logging bucket in L2 Construct
-    const cloudfront_logs_bucket = s3.Bucket.fromCfnBucket(
-      props.aws_logging_stack.cloudfrontLogsBucket.resource
-    );
-    // Create a CDN in front of the demo bucket, with logBucket configured
-    // to the cloudfrontLogsBucket
-    const cdn = new cloudfront.Distribution(this, 'Distro', {
-      defaultBehavior: {
-        origin: new origins.S3Origin(s3Bucket)
-      },
-      logBucket: cloudfront_logs_bucket
-    });
+      *****************/
+      // Wrap L1 logging bucket in L2 Construct
+      const cloudfront_logs_bucket = s3.Bucket.fromCfnBucket(
+        props.aws_logging_stack.cloudfrontLogsBucket.resource
+      );
+      // Create a CDN in front of the demo bucket, with logBucket configured
+      // to the cloudfrontLogsBucket
+      const cdn = new cloudfront.Distribution(this, 'Distro', {
+        defaultBehavior: {
+          origin: new origins.S3Origin(s3Bucket)
+        },
+        logBucket: cloudfront_logs_bucket
+      });
 
-    /*
+
+      /****************
       ALB ACCESS LOGS
-    */
-    //  Wrap L1 bucket in L2 construct
-    // Create a simple Load Balancer
-    const lb = new elbv2.ApplicationLoadBalancer(this, 'LB', {
-          vpc
-    });
+      *****************/
+      //  Wrap L1 bucket in L2 construct
+      // Create a simple Load Balancer
+      const lb = new elbv2.ApplicationLoadBalancer(this, 'LB', {
+        vpc
+      });
 
-    // Send logs to the AlbLogsBucket
-    lb.logAccessLogs(
-      s3.Bucket.fromCfnBucket(props.aws_logging_stack.albLogsBucket.resource )
-    );
+      // Send logs to the AlbLogsBucket
+      lb.logAccessLogs(
+        s3.Bucket.fromCfnBucket(props.aws_logging_stack.albLogsBucket.resource )
+      );
 
-    /*
+
+      /***********
       CLOUDTRAIL
-    */
-    // //  Wrap L1 logging bucket in L2 Construct
-    const cloudtrail_logs_bucket = s3.Bucket.fromCfnBucket(
-      props.aws_logging_stack.cloudtrailLogsBucket.resource
-    );
-    // // Create a Cloudtrail trail that sends logs to the CloudtrailLogsBucket
-    const trail = new cloudtrail.Trail(this, 'myCloudTrail', {
-       bucket: cloudtrail_logs_bucket
-     });
+      ************/
+      // //  Wrap L1 logging bucket in L2 Construct
+      const cloudtrail_logs_bucket = s3.Bucket.fromCfnBucket(
+        props.aws_logging_stack.cloudtrailLogsBucket.resource
+      );
+      // // Create a Cloudtrail trail that sends logs to the CloudtrailLogsBucket
+      const trail = new cloudtrail.Trail(this, 'myCloudTrail', {
+        bucket: cloudtrail_logs_bucket
+      });
 
-     /*
-       SES LOGS
-     */
-     // Wrap L1 logging bucket in L2 Construct
-     const ses_logs_bucket =  s3.Bucket.fromCfnBucket(
-       props.aws_logging_stack.sesLogsBucket.resource
-     );
 
-     // Creates IAM roles for firehose to assume
-     const destinationRole = new iam.Role(this, 'Destination Role', {
-       assumedBy: new iam.ServicePrincipal('firehose.amazonaws.com'),
-     });
-     const deliveryStreamRole = new iam.Role(this, 'Delivery Stream Role', {
-       assumedBy: new iam.ServicePrincipal('firehose.amazonaws.com'),
-     });
-     // Specify the roles created above when defining the destination and delivery stream.
-     const destination = new S3Bucket(ses_logs_bucket, {role: destinationRole});
-     const delivery_stream = new firehose.DeliveryStream(this, 'KinesisStream', {
-       destinations: [destination],
-       role: deliveryStreamRole
-     });
+      /*********
+      SES LOGS
+      **********/
+      // Wrap L1 logging bucket in L2 Construct
+      const ses_logs_bucket =  s3.Bucket.fromCfnBucket(
+        props.aws_logging_stack.sesLogsBucket.resource
+      );
 
-     // Creates an SES ConfigurationSet with reputation metrics enabled
-     const config_set = new ses.ConfigurationSet(this, 'ConfigurationSet', {
-       reputationMetrics: true
-     });
+      // Creates IAM roles for firehose to assume
+      const destinationRole = new iam.Role(this, 'Destination Role', {
+        assumedBy: new iam.ServicePrincipal('firehose.amazonaws.com'),
+      });
+      const deliveryStreamRole = new iam.Role(this, 'Delivery Stream Role', {
+        assumedBy: new iam.ServicePrincipal('firehose.amazonaws.com'),
+      });
+      // Specify the roles created above when defining the destination and delivery stream.
+      const destination = new S3Bucket(ses_logs_bucket, {role: destinationRole});
+      const delivery_stream = new firehose.DeliveryStream(this, 'KinesisStream', {
+        destinations: [destination],
+        role: deliveryStreamRole
+      });
 
-     // Set up permissions for SES to publish events to Kinesis Firehose
-     // Creates service principal we can use to restrict the IAM role to the ConfigurationSet
-     const service_principal = new iam.PrincipalWithConditions(new iam.ServicePrincipal('ses.amazonaws.com'), {
-         "StringEquals": {
-           "AWS:SourceAccount": [process.env.CDK_DEFAULT_ACCOUNT],
-           "AWS:SourceArn": [
-             `arn:aws:ses:${process.env.CDK_DEFAULT_REGION}:${process.env.CDK_DEFAULT_ACCOUNT}:configuration-set/${config_set.configurationSetName}`
-           ]
-         }
-       }
-     );
-     // Create the IAM Role
-     const sesRole = new iam.Role(this, 'SES Role', {
-       assumedBy: new iam.ServicePrincipal('ses.amazonaws.com'),
-       // It's important to add the firehose permissions as inline
-       // policies. If policies are added after role creation, CDK
-       // will not know to wait, and may fail to create the ConfigurationSet
-       // due to insufficient permissions
-       inlinePolicies: {
-         'root': new iam.PolicyDocument({
-           statements: [
-             new iam.PolicyStatement({
-               effect: iam.Effect.ALLOW,
-               actions: [
-                 'firehose:PutRecord',
-                 'firehose:PutRecordBatch'
-               ],
-               resources: [
-                 delivery_stream.deliveryStreamArn
-               ]
-             })
-           ]
-         })
-       }
-     });
+      // Creates an SES ConfigurationSet with reputation metrics enabled
+      const config_set = new ses.ConfigurationSet(this, 'ConfigurationSet', {
+        reputationMetrics: true
+      });
 
-     // Creates a Configuraton Set Event Destination that will send all SES events
-     // to the Kinesis Firehose Stream.
-     const cfnConfigurationSetEventDestination = new ses.CfnConfigurationSetEventDestination(this, 'MyCfnConfigurationSetEventDestination', {
-       configurationSetName: config_set.configurationSetName,
-       eventDestination: {
-         matchingEventTypes: [
-           'send',
-           'reject',
-           'bounce',
-           'complaint',
-           'delivery',
-           'open',
-           'click',
-           'renderingFailure'
-         ],
-         enabled: true,
-         kinesisFirehoseDestination: {
-           deliveryStreamArn: delivery_stream.deliveryStreamArn,
-           iamRoleArn: sesRole.roleArn
-         }
-       }
-     });
-     // TODO: Manually configure any verified SES sending domains or emails for which
-     // event publishing is desired
-   }
+      // Set up permissions for SES to publish events to Kinesis Firehose
+      // Creates service principal we can use to restrict the IAM role to the ConfigurationSet
+      const service_principal = new iam.PrincipalWithConditions(new iam.ServicePrincipal('ses.amazonaws.com'), {
+        "StringEquals": {
+          "AWS:SourceAccount": [process.env.CDK_DEFAULT_ACCOUNT],
+          "AWS:SourceArn": [
+              `arn:aws:ses:${process.env.CDK_DEFAULT_REGION}:${process.env.CDK_DEFAULT_ACCOUNT}:configuration-set/${config_set.configurationSetName}`
+            ]
+          }
+        }
+      );
+      // Create the IAM Role
+      const sesRole = new iam.Role(this, 'SES Role', {
+        assumedBy: new iam.ServicePrincipal('ses.amazonaws.com'),
+        // It's important to add the firehose permissions as inline
+        // policies. If policies are added after role creation, CDK
+        // will not know to wait, and may fail to create the ConfigurationSet
+        // due to insufficient permissions
+        inlinePolicies: {
+          'root': new iam.PolicyDocument({
+            statements: [
+              new iam.PolicyStatement({
+                effect: iam.Effect.ALLOW,
+                actions: [
+                  'firehose:PutRecord',
+                  'firehose:PutRecordBatch'
+                ],
+                resources: [
+                  delivery_stream.deliveryStreamArn
+                ]
+              })
+            ]
+          })
+        }
+      });
+
+      // Creates a Configuraton Set Event Destination that will send all SES events
+      // to the Kinesis Firehose Stream.
+      const cfnConfigurationSetEventDestination = new ses.CfnConfigurationSetEventDestination(this, 'MyCfnConfigurationSetEventDestination', {
+        configurationSetName: config_set.configurationSetName,
+        eventDestination: {
+          matchingEventTypes: [
+            'send',
+            'reject',
+            'bounce',
+            'complaint',
+            'delivery',
+            'open',
+            'click',
+            'renderingFailure'
+          ],
+          enabled: true,
+          kinesisFirehoseDestination: {
+            deliveryStreamArn: delivery_stream.deliveryStreamArn,
+            iamRoleArn: sesRole.roleArn
+          }
+        }
+      });
+      // TODO: Manually configure any verified SES sending domains or emails for which
+      // event publishing is desired
+
+
+      /*****
+       WAF
+      ******/
+      // Create a simple WAF with default settings and no rules
+      const cfnWebACL = new wafv2.CfnWebACL(this, 'MyCfnWebACL', {
+        defaultAction: {
+          allow: {}
+        },
+        scope: 'REGIONAL',
+        visibilityConfig: {
+          cloudWatchMetricsEnabled: true,
+          metricName:'MetricForWebACLCDK',
+          sampledRequestsEnabled: true,
+        },
+      });
+      // Create a logging configuration for the WAF logging bucket
+      const cfnLoggingConfiguration = new wafv2.CfnLoggingConfiguration(this, 'MyCfnLoggingConfiguration', {
+        logDestinationConfigs: [props.aws_logging_stack.wafLogsBucket.bucketArn],
+        resourceArn: cfnWebACL.attrArn
+      });
+    }
 }

--- a/src/stacks/README.md
+++ b/src/stacks/README.md
@@ -131,6 +131,12 @@ An Athena query is created to expose info about rejected internal traffic
 An Athena query is created that exposes failed attempts to access your S3 buckets
 - **s3-request-errors**: Gets the 100 most recent failed S3 access requests.
 
+### SES
+Protect your domain, and your enterprise's, sending reputation by tracking **bounces**
+and **complaints**
+- **ses-bounces**: Gets the 100 most recent bounces from the last day.
+- **ses-complaints**: Gets the 100 most recent complaints from the last day.
+
 #### WAF
 Strategy is implemented for storage of WAF logs in S3 with ETL jobs loading to the
 Glue table, but no default Athena queries have been added yet.

--- a/src/stacks/README.md
+++ b/src/stacks/README.md
@@ -89,7 +89,7 @@ Follow the docs for each service or resource to enable logging to the respective
 - [Enable Logging on an ALB](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_elasticloadbalancingv2.ApplicationLoadBalancer.html#logwbraccesswbrlogsbucket-prefix)
 - [Enable Logging on a CloudFront Distribution](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_cloudfront.Distribution.html#logbucket)
 - [Create A Trail on CloudTrail](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_cloudtrail.Trail.html)
-- [Publish VPC Flow Logs to S3](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ec2.FlowLog.html)
+- [Publish VPC Flow Logs to S3](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ec2.FlowLogDestination.html#static-towbrs3bucket-keyprefix-options)
 - [Enable Server Access logging for S3 Access Logs](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3.CfnBucket.LoggingConfigurationProperty.html)
 - [Stream SES Event logs](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ses.CfnConfigurationSetEventDestination.EventDestinationProperty.html)
   - As described in the documentation linked above, SES event logs first need to

--- a/src/stacks/README.md
+++ b/src/stacks/README.md
@@ -37,7 +37,7 @@ All **cdk-extensions** constructs:
   - [S3 Access Logs](#S3AccessLogs)
   - [SES](#SES)
   - [WAF](#WAF)
-- [More About The Resources](#MoreInfoAboutTheResources)
+- [More Info About The Resources](#MoreInfoAboutTheResources)
 
 ### Summary
 Having a good logging strategy for your AWS Services is a recommended best

--- a/src/stacks/README.md
+++ b/src/stacks/README.md
@@ -93,7 +93,8 @@ Follow the docs for each service or resource to enable logging to the respective
 - [Enable Server Access logging for S3 Access Logs](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3.CfnBucket.LoggingConfigurationProperty.html)
 - [Stream SES Event logs](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ses.CfnConfigurationSetEventDestination.EventDestinationProperty.html)
   - As described in the documentation linked above, SES event logs first need to
-    publish to an intermediate service, such as [Kinesis Firehose](https://docs.aws.amazon.com/cdk/api/v1/docs/aws-kinesisfirehose-readme.html#s3), and then be streamed to the S3 bucket
+    publish to an intermediate service, such as [Kinesis Firehose](https://docs.aws.amazon.com/cdk/api/v1/docs/aws-kinesisfirehose-readme.html#s3), and then be streamed to the S3 bucket(opinionated Firehose constructs are also
+    available in [cdk-extensions/kinesis-firehose](src/kinesis-firehose))
 - [Enable WAF logging to S3](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_wafv2.CfnLoggingConfiguration.html)
 
 ### The Athena Queries

--- a/src/stacks/README.md
+++ b/src/stacks/README.md
@@ -2,27 +2,11 @@
 These are full-stack solutions, offering rapid deployment of commonly used enterprise
 scale patterns with little to no configuration needed.
 
+All Stacks utilize patterns and constructs from the **cdk-extensions** library.
+
 - [About](#AboutTheCDK-ExtensionsLibraries)
 - [Stacks](#Stacks)
   - [AwsLoggingStack](#AwsLoggingStack)
-
-## About The CDK-Extensions Libraries
-All Stacks utilize patterns and constructs from the **cdk-extensions** library.
-
-All **cdk-extensions** constructs:
-- Expose their configurations so other resources can make informed
-  decisions about the resource it’s working on.
-- Are fully compatible with **aws-cdk-lib** constructs
-- Every single field in the resources are exposed, so they can be configured
-  - In some cases, this relies on custom features built into the **cdk-extensions**
-    constructs, to allow configuration of Cfn fields not normally exposed in cdk
-  - Anything that can be configured on a resource should be something that can
-    be customized using CDK
-- However, all fields have sane defaults, following best practices(i.e most secure way)
-  - Using the most secure settings should be a feature one opts out of, not the
-    other way around
-  - We should be able to launch constructs that adhere to best practices without
-    a lot of customization
 
 # Stacks
 


### PR DESCRIPTION
Creates the README for the stacks module, and adds documentation of the AwsLoggingStack. 
- Tested example shows sample code connecting each service to the logging buckets(TS only for now)
  - Uses eventually consistent importing scheme. In testing, needs `import { AwsLoggingStack } from 'cdk-extensions/lib/stacks` to find the module. Standard imports should work in finished version.

Also updates glue-tables README with brief explanation of ETL. 

Corrects CloudTrail bucket naming in s3_buckets readme.

Adds a hyperlink to the AwsLoggingStack example on the front page to get quickly to the new stacks readme.

Finally, a statement of principles is added to the front page. This is taken from notes on Kevin's stated design principles from the meeting last week. I originally had it in a draft of the Stacks README, but think it should be up top. 