### PR TITLE
fix: Predicate logical operator should be optional

### DIFF
--- a/API.md
+++ b/API.md
@@ -39595,7 +39595,7 @@ The AWS region this resource belongs to.
 
 ---
 
-##### `logicalOperator`<sup>Required</sup> <a name="logicalOperator" id="cdk-extensions.glue.WorkflowCrawlerPredicateOptions.property.logicalOperator"></a>
+##### `logicalOperator`<sup>Optional</sup> <a name="logicalOperator" id="cdk-extensions.glue.WorkflowCrawlerPredicateOptions.property.logicalOperator"></a>
 
 ```typescript
 public readonly logicalOperator: PredicateLogicalOperator;

--- a/src/glue/lib/workflow-predicates/crawler-predicate.ts
+++ b/src/glue/lib/workflow-predicates/crawler-predicate.ts
@@ -38,7 +38,7 @@ export interface WorkflowCrawlerPredicateOptions extends WorkflowPredicateOption
    *
    * @see [Trigger Predicate.Conditions.LogicalOperator](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-trigger-condition.html#cfn-glue-trigger-condition-logicaloperator)
    */
-  readonly logicalOperator: PredicateLogicalOperator;
+  readonly logicalOperator?: PredicateLogicalOperator;
 
   /**
    * The state that the crawler must be in in order to meet the criteria to


### PR DESCRIPTION
Allow predicate logical operator field to be null with a default value of EQUALS.