### PR TITLE
fix: Set EC2 as the default consumer for IPAM pools and add validatio…

### DIFF
--- a/API.md
+++ b/API.md
@@ -38606,8 +38606,19 @@ const allocatePrivateNetworkOptions: ec2_patterns.AllocatePrivateNetworkOptions 
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
+| <code><a href="#cdk-extensions.ec2_patterns.AllocatePrivateNetworkOptions.property.consumer">consumer</a></code> | <code>cdk-extensions.ec2.IpamConsumer</code> | *No description.* |
 | <code><a href="#cdk-extensions.ec2_patterns.AllocatePrivateNetworkOptions.property.netmask">netmask</a></code> | <code>number</code> | *No description.* |
 | <code><a href="#cdk-extensions.ec2_patterns.AllocatePrivateNetworkOptions.property.pool">pool</a></code> | <code>string</code> | *No description.* |
+
+---
+
+##### `consumer`<sup>Optional</sup> <a name="consumer" id="cdk-extensions.ec2_patterns.AllocatePrivateNetworkOptions.property.consumer"></a>
+
+```typescript
+public readonly consumer: IpamConsumer;
+```
+
+- *Type:* cdk-extensions.ec2.IpamConsumer
 
 ---
 
@@ -74240,7 +74251,7 @@ ec2.IpamConsumer.of(name: string)
 
 ---
 
-##### `name`<sup>Required</sup> <a name="name" id="cdk-extensions.ec2.IpamConsumer.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="name" id="cdk-extensions.ec2.IpamConsumer.property.name"></a>
 
 ```typescript
 public readonly name: string;
@@ -74255,6 +74266,7 @@ public readonly name: string;
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#cdk-extensions.ec2.IpamConsumer.property.EC2">EC2</a></code> | <code>cdk-extensions.ec2.IpamConsumer</code> | *No description.* |
+| <code><a href="#cdk-extensions.ec2.IpamConsumer.property.NONE">NONE</a></code> | <code>cdk-extensions.ec2.IpamConsumer</code> | *No description.* |
 
 ---
 
@@ -74262,6 +74274,16 @@ public readonly name: string;
 
 ```typescript
 public readonly EC2: IpamConsumer;
+```
+
+- *Type:* cdk-extensions.ec2.IpamConsumer
+
+---
+
+##### `NONE`<sup>Required</sup> <a name="NONE" id="cdk-extensions.ec2.IpamConsumer.property.NONE"></a>
+
+```typescript
+public readonly NONE: IpamConsumer;
 ```
 
 - *Type:* cdk-extensions.ec2.IpamConsumer
@@ -83016,6 +83038,7 @@ public allocateCidrFromPool(id: string, options?: AllocateCidrFromPoolOptions): 
 | <code><a href="#cdk-extensions.ec2.IIpamPool.property.ipamPoolScopeType">ipamPoolScopeType</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#cdk-extensions.ec2.IIpamPool.property.ipamPoolState">ipamPoolState</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#cdk-extensions.ec2.IIpamPool.property.ipamPoolStateMessage">ipamPoolStateMessage</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#cdk-extensions.ec2.IIpamPool.property.consumer">consumer</a></code> | <code>cdk-extensions.ec2.IpamConsumer</code> | *No description.* |
 
 ---
 
@@ -83139,6 +83162,16 @@ public readonly ipamPoolStateMessage: string;
 ```
 
 - *Type:* string
+
+---
+
+##### `consumer`<sup>Optional</sup> <a name="consumer" id="cdk-extensions.ec2.IIpamPool.property.consumer"></a>
+
+```typescript
+public readonly consumer: IpamConsumer;
+```
+
+- *Type:* cdk-extensions.ec2.IpamConsumer
 
 ---
 

--- a/src/ec2-patterns/four-tier-network.ts
+++ b/src/ec2-patterns/four-tier-network.ts
@@ -3,7 +3,7 @@ import { DefaultInstanceTenancy, FlowLogResourceType, GatewayVpcEndpointOptions,
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import { IConstruct } from 'constructs';
 import { IpAddressManager } from '.';
-import { FlowLog, FlowLogFormat, IIpamPool } from '../ec2';
+import { FlowLog, FlowLogFormat, IIpamPool, IpamConsumer } from '../ec2';
 import { TieredSubnets } from '../ec2/lib';
 import { ICidrProvider, CidrProvider } from '../ec2/lib/ip-addresses/network-provider';
 
@@ -97,6 +97,14 @@ export class FourTierNetwork extends Vpc {
     this.enableDnsSupport = props?.enableDnsSupport;
     this.maxAzs = props?.maxAzs;
     this.vpcName = props?.vpcName;
+
+    const ipamService = this.ipamPool?.consumer?.name;
+    if (this.ipamPool?.consumer && ipamService !== IpamConsumer.EC2.name) {
+      throw new Error([
+        'When using an IPAM pool to allocate a CIDR for a VPC the pool needs',
+        `to have '${IpamConsumer.EC2.name}' set as its consumer.`,
+      ].join(' '));
+    }
 
     if (props?.flowLogs === undefined || Object.keys(props.flowLogs).length > 0) {
       const flowLogs = props?.flowLogs ?? {

--- a/src/ec2/ipam-pool.ts
+++ b/src/ec2/ipam-pool.ts
@@ -10,13 +10,14 @@ import { DynamicReference } from '../core/dynamic-reference';
 
 export class IpamConsumer {
   public static readonly EC2: IpamConsumer = IpamConsumer.of('ec2');
+  public static readonly NONE: IpamConsumer = new IpamConsumer();
 
   public static of(name: string): IpamConsumer {
     return new IpamConsumer(name);
   }
 
 
-  private constructor(public readonly name: string) {}
+  private constructor(public readonly name?: string) {}
 }
 
 export class PublicIpSource {
@@ -40,6 +41,8 @@ export interface IIpamPool extends IResource {
   readonly ipamPoolScopeType: string;
   readonly ipamPoolState: string;
   readonly ipamPoolStateMessage: string;
+
+  readonly consumer?: IpamConsumer;
 
   addCidrToPool(id: string, options: AddCidrToPoolOptions): AddCidrToPoolResult;
   addChildPool(id: string, options?: AddChildPoolOptions): IIpamPool;
@@ -138,7 +141,6 @@ export class IpamPool extends IpamPoolBase {
   // Input properties
   public readonly addressConfiguration?: AddressConfiguration;
   public readonly autoImport?: boolean;
-  public readonly consumer?: IpamConsumer;
   public readonly description?: string;
   public readonly ipamScope: IIpamScope;
   public readonly locale?: string;
@@ -149,6 +151,7 @@ export class IpamPool extends IpamPoolBase {
   // Resource properties
   public readonly resource: CfnIPAMPool;
 
+  public readonly consumer?: IpamConsumer;
   public readonly ipamPoolArn: string;
   public readonly ipamPoolDepth: number;
   public readonly ipamPoolIpamArn: string;
@@ -167,7 +170,7 @@ export class IpamPool extends IpamPoolBase {
 
     this.addressConfiguration = props.addressConfiguration ?? AddressConfiguration.ipv4();
     this.autoImport = props.autoImport;
-    this.consumer = props.consumer;
+    this.consumer = props.consumer ?? IpamConsumer.EC2;
     this.description = props.description;
     this.ipamScope = props.ipamScope;
     this.locale = props.locale;


### PR DESCRIPTION
Adds validation around IPAM pool AWS service association and makes EC2 association the default.