### PR TITLE
fix: Fix the padding for client vpn dynamic route names

### DIFF
--- a/src/ec2-patterns/network-isolated-client-vpn-endpoint.ts
+++ b/src/ec2-patterns/network-isolated-client-vpn-endpoint.ts
@@ -182,7 +182,7 @@ export class NetworkIsolatedClientVpnEndpoint extends Resource implements IConne
 
   public addMultiSubnetRoute(id: string, options: AddMultiSubnetRouteOptions): any {
     this.subnets.forEach((x, idx) => {
-      const uid = `vpc-${id}-${(idx + 1).toString().padStart(1, '0')}`;
+      const uid = `vpc-${id}-${(idx + 1).toString().padStart(2, '0')}`;
       if (!options.scope) {
         this.clientVpnEndpoint.addRoute(uid, {
           cidr: options.cidr,


### PR DESCRIPTION
Fix the padding for client vpn dynamic route ids